### PR TITLE
Update consensus interface

### DIFF
--- a/vetomint/src/lib.rs
+++ b/vetomint/src/lib.rs
@@ -36,18 +36,12 @@ pub enum ConsensusEvent {
         proposer: ValidatorIndex,
         round: Round,
         time: Timestamp,
-    },
-    /// Informs that the node is in favor of or against a proposal.
-    ProposalFavor {
-        proposal: BlockIdentifier,
         /// Whether this node is in favor of the proposal.
         favor: bool,
-        time: Timestamp,
     },
-    /// Informs that `CreateProposal` has been completed.
-    BlockProposalCreated {
+    /// Updates the block candidate which this node wants to propose in its turn.
+    BlockCandidateUpdated {
         proposal: BlockIdentifier,
-        round: Round,
         time: Timestamp,
     },
     /// Informs that the node has received a block prevote.
@@ -85,8 +79,7 @@ impl ConsensusEvent {
         match self {
             ConsensusEvent::Start { time, .. } => *time,
             ConsensusEvent::BlockProposalReceived { time, .. } => *time,
-            ConsensusEvent::ProposalFavor { time, .. } => *time,
-            ConsensusEvent::BlockProposalCreated { time, .. } => *time,
+            ConsensusEvent::BlockCandidateUpdated { time, .. } => *time,
             ConsensusEvent::Prevote { time, .. } => *time,
             ConsensusEvent::Precommit { time, .. } => *time,
             ConsensusEvent::NilPrevote { time, .. } => *time,
@@ -146,6 +139,9 @@ pub struct HeightInfo {
 
     /// The consensus parameters
     pub consensus_params: ConsensusParams,
+
+    /// The initial block candidate that this node wants to propose.
+    pub initial_block_candidate: BlockIdentifier,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -176,11 +172,14 @@ pub struct ConsensusState {
 
     votes: BTreeMap<Round, Votes>,
     waiting_for_proposal_creation: bool,
+
+    block_candidate: BlockIdentifier,
+    height_info: HeightInfo,
 }
 
 impl ConsensusState {
     /// Prepares the initial state of the consensus.
-    pub fn new(_height_info: HeightInfo) -> Self {
+    pub fn new(height_info: HeightInfo) -> Self {
         ConsensusState {
             step: ConsensusStep::Initial,
             round: 0,
@@ -191,6 +190,8 @@ impl ConsensusState {
             timeout_propose: None,
             votes: Default::default(),
             waiting_for_proposal_creation: false,
+            block_candidate: height_info.initial_block_candidate,
+            height_info,
         }
     }
 
@@ -198,12 +199,8 @@ impl ConsensusState {
     ///
     /// It returns `None` if the state machine is not ready to process the event.
     /// It returns `Some(Vec![])` if the state machine processed the event but did not emit any response.
-    pub fn progress(
-        &mut self,
-        height_info: &HeightInfo,
-        event: ConsensusEvent,
-    ) -> Option<Vec<ConsensusResponse>> {
-        progress::progress(height_info, self, event)
+    pub fn progress(&mut self, event: ConsensusEvent) -> Option<Vec<ConsensusResponse>> {
+        progress::progress(self, event)
     }
 }
 

--- a/vetomint/src/progress.rs
+++ b/vetomint/src/progress.rs
@@ -9,7 +9,13 @@ use super::*;
 /// - on-4f-favor-precommit
 /// - OnTimeoutPrecommit
 pub(super) fn progress(
-    height_info: &HeightInfo,
+    _state: &mut ConsensusState,
+    _event: ConsensusEvent,
+) -> Option<Vec<ConsensusResponse>> {
+    unimplemented!()
+}
+#[cfg(ignore)]
+pub(super) fn progress(
     state: &mut ConsensusState,
     event: ConsensusEvent,
 ) -> Option<Vec<ConsensusResponse>> {

--- a/vetomint/tests/integration_test.rs
+++ b/vetomint/tests/integration_test.rs
@@ -11,6 +11,7 @@ fn success_trivial_1() {
             timeout_ms: 1000,
             repeat_round_for_first_leader: 1,
         },
+        initial_block_candidate: 0,
     };
     let mut state = ConsensusState::new(height_info.clone());
 
@@ -20,15 +21,9 @@ fn success_trivial_1() {
         proposer: 0,
         round: 0,
         time: 1,
-    };
-    let response = state.progress(&height_info, event).unwrap();
-    assert!(response.is_empty());
-    let event = ConsensusEvent::ProposalFavor {
-        proposal: 0,
         favor: true,
-        time: 2,
     };
-    let response = state.progress(&height_info, event).unwrap();
+    let response = state.progress(event).unwrap();
     assert_eq!(
         response,
         vec![ConsensusResponse::BroadcastPrevote {
@@ -45,7 +40,7 @@ fn success_trivial_1() {
             signer: validator_index,
             time: 3,
         };
-        let response = state.progress(&height_info, event).unwrap();
+        let response = state.progress(event).unwrap();
         assert!(response.is_empty());
     }
     let event = ConsensusEvent::Prevote {
@@ -54,7 +49,7 @@ fn success_trivial_1() {
         signer: 3,
         time: 3,
     };
-    let response = state.progress(&height_info, event).unwrap();
+    let response = state.progress(event).unwrap();
     assert_eq!(
         response,
         vec![ConsensusResponse::BroadcastPrecommit {
@@ -71,7 +66,7 @@ fn success_trivial_1() {
             signer: validator_index,
             time: 4,
         };
-        let response = state.progress(&height_info, event).unwrap();
+        let response = state.progress(event).unwrap();
         assert!(response.is_empty());
     }
     let event = ConsensusEvent::Precommit {
@@ -80,7 +75,7 @@ fn success_trivial_1() {
         signer: 3,
         time: 4,
     };
-    let response = state.progress(&height_info, event).unwrap();
+    let response = state.progress(event).unwrap();
     assert_eq!(
         response,
         vec![ConsensusResponse::FinalizeBlock { proposal: 0 }]


### PR DESCRIPTION
Now `favor()` and `get_value()` are totally synchronous.
This will make the implementation much easier.

I know that this update should have been early (because it's about a huge interface change)
but the 'lower layer' has just became more concrete and now it turns out to be feasible to fit in this interface.

Please consider this interface and leave comments or ask questions.
If it's ok, then apply to your work.

This has two significant effects.
1. Since the interface become much simpler, the implementation will be simple as well. Synchronous `favor()` and `get_value()` will directly fit into the pseudo code.
2. Possible transition to ordinary Tendermint will be super easy. (Non-interactive interface)

**This is a DRAFT PR. This is not for merging**
