### PR TITLE
Add some unit tests for PeerDiscoveryImpl

### DIFF
--- a/network/src/peer_discovery/tests.rs
+++ b/network/src/peer_discovery/tests.rs
@@ -101,6 +101,7 @@ struct TestNet {
     nodes: Vec<TestNetNode>,
 }
 
+#[allow(dead_code)]
 /// The set of methods that will be directly called by test functions.
 impl TestNet {
     fn new() -> Self {
@@ -236,13 +237,93 @@ impl TestNet {
     }
 }
 
+#[ignore = "unimplemented"]
 #[tokio::test]
-#[should_panic = "not implemented"]
-async fn demo_test() {
+async fn sequential_join_1() {
+    let mut testnet = TestNet::new();
+    for _ in 0..5 {
+        testnet.add_members(1).await;
+        wait_ms(2_000).await;
+    }
+    wait_ms(3_000).await;
+    testnet.panic_if_discovery_failed().await;
+}
+
+#[ignore = "unimplemented"]
+#[tokio::test]
+async fn sequential_join_2() {
+    let mut testnet = TestNet::new();
+    for _ in 0..10 {
+        testnet.add_members(1).await;
+        wait_ms(1_000).await;
+    }
+    wait_ms(3_000).await;
+    testnet.panic_if_discovery_failed().await;
+}
+
+#[ignore = "unimplemented"]
+#[tokio::test]
+async fn sequential_join_3() {
+    let mut testnet = TestNet::new();
+    for _ in 0..30 {
+        testnet.add_members(1).await;
+        wait_ms(200).await;
+    }
+    wait_ms(3_000).await;
+    testnet.panic_if_discovery_failed().await;
+}
+
+#[ignore = "unimplemented"]
+#[tokio::test]
+async fn concurrent_join_1() {
     let mut testnet = TestNet::new();
     testnet.add_members(10).await;
-    wait_ms(10_000).await;
-    testnet.remove_members(vec![0, 3, 4]);
+    wait_ms(3_000).await;
+    testnet.panic_if_discovery_failed().await;
+}
+
+#[ignore = "unimplemented"]
+#[tokio::test]
+async fn concurrent_join_2() {
+    let mut testnet = TestNet::new();
+    testnet.add_members(30).await;
+    wait_ms(3_000).await;
+    testnet.panic_if_discovery_failed().await;
+}
+
+#[ignore = "unimplemented"]
+#[tokio::test]
+async fn arbitrary_join_1() {
+    // 20 nodes
+    let mut testnet = TestNet::new();
     testnet.add_members(3).await;
+    for _ in 0..5 {
+        testnet.add_members(1).await;
+        wait_ms(200).await;
+    }
+    testnet.add_members(3).await;
+    testnet.add_members(5).await;
+    for _ in 0..4 {
+        testnet.add_members(1).await;
+        wait_ms(500).await;
+    }
+    wait_ms(3_000).await;
+    testnet.panic_if_discovery_failed().await;
+}
+
+#[ignore = "unimplemented"]
+#[tokio::test]
+async fn arbitrary_join_2() {
+    // 15 nodes
+    let mut testnet = TestNet::new();
+    testnet.add_members(4).await;
+    for _ in 0..3 {
+        testnet.add_members(1).await;
+        wait_ms(1_000).await;
+    }
+    testnet.add_members(4).await;
+    wait_ms(5_000).await;
+    testnet.add_members(4).await;
+    wait_ms(3_000).await;
     testnet.panic_if_discovery_failed().await;
 }

--- a/network/src/peer_discovery/tests.rs
+++ b/network/src/peer_discovery/tests.rs
@@ -143,7 +143,12 @@ impl TestNet {
     async fn panic_if_discovery_failed(&self) {
         for node in &self.nodes {
             let known_peers = node.shared_known_peers.read().await;
-            self.panic_if_known_peers_is_incorrect(known_peers);
+            self.panic_if_known_peers_is_incorrect(known_peers.to_owned());
+            let recently_seen_peers = known_peers
+                .iter()
+                .filter(|peer| self.is_peer_recently_seen(peer))
+                .collect();
+            self.panic_if_recently_seen_peers_incorrect(recently_seen_peers);
         }
     }
 }
@@ -202,11 +207,6 @@ impl TestNet {
         for peer in &known_peers {
             assert!(self.is_peer_a_member(peer));
         }
-        let recently_seen_peers = known_peers
-            .iter()
-            .filter(|peer| self.is_peer_recently_seen(peer))
-            .collect();
-        self.panic_if_recently_seen_peers_incorrect(recently_seen_peers);
     }
 
     fn is_peer_a_member(&self, peer: &Peer) -> bool {

--- a/network/src/peer_discovery/tests.rs
+++ b/network/src/peer_discovery/tests.rs
@@ -88,6 +88,12 @@ struct TestNetNode {
     network_config: NetworkConfig,
 }
 
+impl Drop for TestNetNode {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
 /// A network model of peer discovery nodes.
 struct TestNet {
     keystore: KeyStore,
@@ -130,7 +136,6 @@ impl TestNet {
         indices.sort();
         indices.reverse();
         for index in indices {
-            self.nodes[index].handle.abort();
             self.nodes.remove(index);
         }
     }

--- a/network/src/peer_discovery/tests.rs
+++ b/network/src/peer_discovery/tests.rs
@@ -14,9 +14,9 @@ use tokio::{
 const MAX_NODES: u64 = 300;
 const AVAILABLE_PORT_RANGE: Range<u16> = 55000..56000;
 const MAX_INITIALLY_KNOWN_PEERS: u64 = 2;
-// prime number
+/// A prime number used in RNG.
 const LCG_MULTIPLIER: u64 = 16536801242360453141;
-// in seconds
+/// An allowed amount of difference between real timestamp and discovered timestamp, in seconds.
 const PERMITTED_ERROR_FOR_PEER_DISCOVERY: u64 = 10;
 
 type Keypair = (PublicKey, PrivateKey);


### PR DESCRIPTION
- add unit tests
- other minor fixes

Please note that the only action the nodes take is joining the network.
This is because currently we don't have an interface that modifies a node (i.e. changing a node's status string).