### PR TITLE
resloving issue117 (renaming)

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -41,17 +41,17 @@ pub enum ConsensusMessage {
         /// The hash of the voted block
         Hash256,
     ),
-    NonNilPreComitted(ConsensusRound, Hash256),
+    NonNilPreCommitted(ConsensusRound, Hash256),
     NilPreVoted(ConsensusRound),
-    NilPreComitted(ConsensusRound),
+    NilPreCommitted(ConsensusRound),
 }
 
 pub enum ProgressResult {
     Proposed(ConsensusRound, Hash256, Timestamp),
     NonNilPreVoted(ConsensusRound, Hash256, Timestamp),
-    NonNilPreComitted(ConsensusRound, Hash256, Timestamp),
+    NonNilPreCommitted(ConsensusRound, Hash256, Timestamp),
     NilPreVoted(ConsensusRound, Timestamp),
-    NilPreComitted(ConsensusRound, Timestamp),
+    NilPreCommitted(ConsensusRound, Timestamp),
     Finalized(Hash256, Timestamp),
 }
 
@@ -235,7 +235,7 @@ impl<N: GossipNetwork, S: Storage> Consensus<N, S> {
                         .iter()
                         .position(|h| h == &block_hash)
                         .expect("this must be already verified by the message filter");
-                    ConsensusEvent::Prevote {
+                        ConsensusEvent::NonNilPrevote {
                         proposal: index,
                         signer,
                         round: round as usize,

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -235,7 +235,7 @@ impl<N: GossipNetwork, S: Storage> Consensus<N, S> {
                         .iter()
                         .position(|h| h == &block_hash)
                         .expect("this must be already verified by the message filter");
-                        ConsensusEvent::NonNilPrevote {
+                    ConsensusEvent::NonNilPrevote {
                         proposal: index,
                         signer,
                         round: round as usize,

--- a/docs/vetomint_spec/vetomint-spec.tex
+++ b/docs/vetomint_spec/vetomint-spec.tex
@@ -92,7 +92,7 @@
 
 \begin{document}
 
-\section{Tendermint consensus algorithm} \label{sec:tendermint}
+\section{Vetomint consensus algorithm} \label{sec:vetomint}
 
 \newcommand\Disseminate{\textbf{Disseminate}}
 
@@ -166,7 +166,7 @@
 		\ENDUPON
 		
 		\SPACE 
-		\LINECOMMENT{on-4f-favor-prevote-propose-step}
+		\LINECOMMENT{on-4f-non-nil-prevote-in-propose-step}
 		\UPON{$\li{\Proposal,round_p, v, vr}$ \From\ $\coord(round_p)$
 			\textbf{AND} $4f+1$ $\li{\Prevote,vr,id(v)}$  \With\ $step_p = \propose \wedge (vr \ge 0 \wedge vr < round_p)$}
 		\label{line:tab:acceptProposal} 
@@ -184,7 +184,7 @@
 		
 		
 		\SPACE 
-		\LINECOMMENT{on-4f-favor-prevote-prevote-step}
+		\LINECOMMENT{on-4f-non-nil-prevote-in-prevote-step}
 		\UPON{$\li{\Proposal,round_p, v, *}$ \From\ $\coord(round_p)$
 			\textbf{AND} $4f+1$ $\li{\Prevote, round_p,id(v)}$  \With\ $valid(v) \wedge step_p \ge \prevote$ for the first time}
 		\label{line:tab:recvPrevote} 
@@ -231,7 +231,7 @@
 		\ENDUPON 
 		
 		\SPACE 
-		\LINECOMMENT{on-4f-favor-precommit}
+		\LINECOMMENT{on-4f-non-nil-precommit}
 		\UPON{$\li{\Proposal,r, v, *}$ \From\ $\coord(r)$ \textbf{AND}
 			$4f+1$ $\li{\Precommit,r,id(v)}$ \With\ $decision_p = \nil$}
 		\label{line:tab:onDecideRule} 
@@ -256,20 +256,11 @@
 			\STATE $StartRound(round_p + 1)$ \label{line:tab:nextRound} 
 		\ENDIF
 		\ENDFUNCTION	
-	\end{algorithmic} \caption{Tendermint consensus algorithm}
-	\label{alg:tendermint} 
+	\end{algorithmic} \caption{Vetomint consensus algorithm}
+	\label{alg:vetomint} 
 \end{algorithm}
 
 We assume $6f+1$ voting power where at most $f$ of it is byzantine.
-
-\section{수정사항}
-
-
-\begin{enumerate}
-	\item prevote timeout 없앰
-	\item height 개념 없앰
-	\item precommit timeout 조건 $4f+1$에서 $5f+1$로 변경 
-\end{enumerate}
 
 
 \end{document}

--- a/vetomint/src/lib.rs
+++ b/vetomint/src/lib.rs
@@ -47,14 +47,14 @@ pub enum ConsensusEvent {
         time: Timestamp,
     },
     /// Informs that the node has received a block prevote.
-    Prevote {
+    NonNilPrevote {
         proposal: BlockIdentifier,
         signer: ValidatorIndex,
         round: Round,
         time: Timestamp,
     },
     /// Informs that the node has received a block precommit.
-    Precommit {
+    NonNilPrecommit {
         proposal: BlockIdentifier,
         signer: ValidatorIndex,
         round: Round,
@@ -83,8 +83,8 @@ impl ConsensusEvent {
             ConsensusEvent::Start { time, .. } => *time,
             ConsensusEvent::BlockProposalReceived { time, .. } => *time,
             ConsensusEvent::BlockCandidateUpdated { time, .. } => *time,
-            ConsensusEvent::Prevote { time, .. } => *time,
-            ConsensusEvent::Precommit { time, .. } => *time,
+            ConsensusEvent::NonNilPrevote { time, .. } => *time,
+            ConsensusEvent::NonNilPrecommit { time, .. } => *time,
             ConsensusEvent::NilPrevote { time, .. } => *time,
             ConsensusEvent::NilPrecommit { time, .. } => *time,
             ConsensusEvent::Timer { time, .. } => *time,
@@ -103,11 +103,11 @@ pub enum ConsensusResponse {
         proposal: BlockIdentifier,
         round: Round,
     },
-    BroadcastPrevote {
+    BroadcastNonNilPrevote {
         proposal: BlockIdentifier,
         round: Round,
     },
-    BroadcastPrecommit {
+    BroadcastNonNilPrecommit {
         proposal: BlockIdentifier,
         round: Round,
     },

--- a/vetomint/tests/integration_test.rs
+++ b/vetomint/tests/integration_test.rs
@@ -33,7 +33,7 @@ fn early_termination_by_polka_1() {
     let response = state.progress(event).unwrap();
     assert_eq!(
         response,
-        vec![ConsensusResponse::BroadcastPrevote {
+        vec![ConsensusResponse::BroadcastNonNilPrevote {
             proposal: 0,
             round: 0
         }]
@@ -41,7 +41,7 @@ fn early_termination_by_polka_1() {
 
     // STEP 2: Prevote.
     for validator_index in 0..=1 {
-        let event = ConsensusEvent::Prevote {
+        let event = ConsensusEvent::NonNilPrevote {
             proposal: 0,
             round: 0,
             signer: validator_index,
@@ -50,7 +50,7 @@ fn early_termination_by_polka_1() {
         let response = state.progress(event).unwrap();
         assert!(response.is_empty());
     }
-    let event = ConsensusEvent::Prevote {
+    let event = ConsensusEvent::NonNilPrevote {
         proposal: 0,
         round: 0,
         signer: 2,
@@ -59,7 +59,7 @@ fn early_termination_by_polka_1() {
     let response = state.progress(event).unwrap();
     assert_eq!(
         response,
-        vec![ConsensusResponse::BroadcastPrecommit {
+        vec![ConsensusResponse::BroadcastNonNilPrecommit {
             proposal: 0,
             round: 0
         }]
@@ -67,7 +67,7 @@ fn early_termination_by_polka_1() {
 
     // STEP 3: Precommit.
     for validator_index in 0..=1 {
-        let event = ConsensusEvent::Precommit {
+        let event = ConsensusEvent::NonNilPrecommit {
             proposal: 0,
             round: 0,
             signer: validator_index,
@@ -76,7 +76,7 @@ fn early_termination_by_polka_1() {
         let response = state.progress(event).unwrap();
         assert!(response.is_empty());
     }
-    let event = ConsensusEvent::Precommit {
+    let event = ConsensusEvent::NonNilPrecommit {
         proposal: 0,
         round: 0,
         signer: 2,
@@ -119,7 +119,7 @@ fn duplicate_prevotes_and_precommits() {
     let response = state.progress(event).unwrap();
     assert_eq!(
         response,
-        vec![ConsensusResponse::BroadcastPrevote {
+        vec![ConsensusResponse::BroadcastNonNilPrevote {
             proposal: 0,
             round: 0
         }]
@@ -128,7 +128,7 @@ fn duplicate_prevotes_and_precommits() {
     // STEP 2: Duplicate Prevote.
     for _ in 0..2 {
         for validator_index in 0..=2 {
-            let event = ConsensusEvent::Prevote {
+            let event = ConsensusEvent::NonNilPrevote {
                 proposal: 0,
                 round: 0,
                 signer: validator_index,
@@ -138,7 +138,7 @@ fn duplicate_prevotes_and_precommits() {
             assert!(response.is_empty());
         }
     }
-    let event = ConsensusEvent::Prevote {
+    let event = ConsensusEvent::NonNilPrevote {
         proposal: 0,
         round: 0,
         signer: 3,
@@ -147,7 +147,7 @@ fn duplicate_prevotes_and_precommits() {
     let response = state.progress(event).unwrap();
     assert_eq!(
         response,
-        vec![ConsensusResponse::BroadcastPrecommit {
+        vec![ConsensusResponse::BroadcastNonNilPrecommit {
             proposal: 0,
             round: 0
         }]
@@ -156,7 +156,7 @@ fn duplicate_prevotes_and_precommits() {
     // STEP 3: Duplicate Precommit.
     for _ in 0..2 {
         for validator_index in 0..=2 {
-            let event = ConsensusEvent::Precommit {
+            let event = ConsensusEvent::NonNilPrecommit {
                 proposal: 0,
                 round: 0,
                 signer: validator_index,
@@ -166,7 +166,7 @@ fn duplicate_prevotes_and_precommits() {
             assert!(response.is_empty());
         }
     }
-    let event = ConsensusEvent::Precommit {
+    let event = ConsensusEvent::NonNilPrecommit {
         proposal: 0,
         round: 0,
         signer: 3,
@@ -208,7 +208,7 @@ fn early_termination_by_polka_2() {
     let response = state.progress(event).unwrap();
     assert_eq!(
         response,
-        vec![ConsensusResponse::BroadcastPrevote {
+        vec![ConsensusResponse::BroadcastNonNilPrevote {
             proposal: 0,
             round: 0
         }]
@@ -216,7 +216,7 @@ fn early_termination_by_polka_2() {
 
     // STEP 2: Prevote.
     for validator_index in 0..=2 {
-        let event = ConsensusEvent::Prevote {
+        let event = ConsensusEvent::NonNilPrevote {
             proposal: 0,
             round: 0,
             signer: validator_index,
@@ -233,7 +233,7 @@ fn early_termination_by_polka_2() {
     let response = state.progress(event).unwrap();
     assert!(response.is_empty());
 
-    let event = ConsensusEvent::Prevote {
+    let event = ConsensusEvent::NonNilPrevote {
         proposal: 0,
         round: 0,
         signer: 4,
@@ -242,7 +242,7 @@ fn early_termination_by_polka_2() {
     let response = state.progress(event).unwrap();
     assert_eq!(
         response,
-        vec![ConsensusResponse::BroadcastPrecommit {
+        vec![ConsensusResponse::BroadcastNonNilPrecommit {
             proposal: 0,
             round: 0
         }]
@@ -250,7 +250,7 @@ fn early_termination_by_polka_2() {
 
     // STEP 3: Precommit.
     for validator_index in 0..=2 {
-        let event = ConsensusEvent::Precommit {
+        let event = ConsensusEvent::NonNilPrecommit {
             proposal: 0,
             round: 0,
             signer: validator_index,
@@ -259,7 +259,7 @@ fn early_termination_by_polka_2() {
         let response = state.progress(event).unwrap();
         assert!(response.is_empty());
     }
-    let event = ConsensusEvent::Precommit {
+    let event = ConsensusEvent::NonNilPrecommit {
         proposal: 0,
         round: 0,
         signer: 3,
@@ -407,7 +407,7 @@ fn precommit_timeout_and_broadcast_proposal() {
     );
 
     // STEP 2: Prevote.
-    let event = ConsensusEvent::Prevote {
+    let event = ConsensusEvent::NonNilPrevote {
         proposal: 0,
         round: 0,
         signer: 0,
@@ -425,7 +425,7 @@ fn precommit_timeout_and_broadcast_proposal() {
     assert!(response.is_empty());
 
     for validator_index in 3..=4 {
-        let event = ConsensusEvent::Prevote {
+        let event = ConsensusEvent::NonNilPrevote {
             proposal: 0,
             round: 0,
             signer: validator_index,
@@ -435,7 +435,7 @@ fn precommit_timeout_and_broadcast_proposal() {
         assert!(response.is_empty());
     }
 
-    let event = ConsensusEvent::Prevote {
+    let event = ConsensusEvent::NonNilPrevote {
         proposal: 0,
         round: 0,
         signer: 5,
@@ -515,7 +515,7 @@ fn double_vote_violation() {
     let response = state.progress(event).unwrap();
     assert_eq!(
         response,
-        vec![ConsensusResponse::BroadcastPrevote {
+        vec![ConsensusResponse::BroadcastNonNilPrevote {
             proposal: 0,
             round: 0
         }]
@@ -523,7 +523,7 @@ fn double_vote_violation() {
 
     // STEP 2: Prevote.
     for validator_index in 0..=2 {
-        let event = ConsensusEvent::Prevote {
+        let event = ConsensusEvent::NonNilPrevote {
             proposal: 0,
             round: 0,
             signer: validator_index,
@@ -532,7 +532,7 @@ fn double_vote_violation() {
         let response = state.progress(event).unwrap();
         assert!(response.is_empty());
     }
-    let event = ConsensusEvent::Prevote {
+    let event = ConsensusEvent::NonNilPrevote {
         proposal: 1,
         round: 0,
         signer: 2,

--- a/vetomint/tests/unit_action.rs
+++ b/vetomint/tests/unit_action.rs
@@ -35,31 +35,31 @@ pub fn prevotes(
     let total_voting_power: u64 = height_info.validators.iter().sum();
     votes_time_sorted.sort_by_key(|k| k.3);
 
-    let mut current_prevoted = if favor_of_this_node.0 {
+    let mut current_non_nil_prevoted = if favor_of_this_node.0 {
         favor_of_this_node.1
     } else {
         0
     };
-    let mut current_nilvoted = if !favor_of_this_node.0 {
+    let mut current_nil_prevoted = if !favor_of_this_node.0 {
         favor_of_this_node.1
     } else {
         0
     };
-    let mut current_voted;
+    let mut current_prevoted;
     let mut return_responses = Vec::<Option<Vec<ConsensusResponse>>>::new();
 
     for (signer, favor, power, time) in votes_time_sorted {
-        current_voted = current_prevoted + current_nilvoted;
-        if 3 * current_prevoted > 2 * total_voting_power
-            || 3 * current_nilvoted > 2 * total_voting_power
-            || 6 * current_voted > total_voting_power
+        current_prevoted = current_non_nil_prevoted + current_nilvoted;
+        if 3 * current_non_nil_prevoted > 2 * total_voting_power
+            || 3 * current_nil_prevoted > 2 * total_voting_power
+            || 6 * current_prevoted > total_voting_power
         {
             assertion_check(&return_responses);
             return return_responses;
         }
 
         if favor {
-            let event = ConsensusEvent::Prevote {
+            let event = ConsensusEvent::NonNilPrevote {
                 proposal,
                 signer,
                 round,
@@ -67,7 +67,7 @@ pub fn prevotes(
             };
             let response = state.progress(event);
             return_responses.push(response);
-            current_prevoted += power;
+            current_non_nil_prevoted += power;
         } else {
             let event = ConsensusEvent::NilPrevote {
                 signer,
@@ -76,7 +76,7 @@ pub fn prevotes(
             };
             let response = state.progress(event);
             return_responses.push(response);
-            current_nilvoted += power;
+            current_nil_prevoted += power;
         }
     }
     assertion_check(&return_responses);
@@ -96,12 +96,12 @@ pub fn precommits(
     let total_voting_power: u64 = height_info.validators.iter().sum();
     commits_time_sorted.sort_by_key(|k| k.3);
 
-    let mut current_precommitted = if favor_of_this_node.0 {
+    let mut current_non_nil_precommitted = if favor_of_this_node.0 {
         favor_of_this_node.1
     } else {
         0
     };
-    let mut current_nilcommitted = if !favor_of_this_node.0 {
+    let mut current_nil_precommitted = if !favor_of_this_node.0 {
         favor_of_this_node.1
     } else {
         0
@@ -109,14 +109,14 @@ pub fn precommits(
     let mut return_responses = Vec::<Option<Vec<ConsensusResponse>>>::new();
 
     for (signer, favor, power, time) in commits_time_sorted {
-        if 3 * current_precommitted > 2 * total_voting_power
-            || 3 * current_nilcommitted > 2 * total_voting_power
+        if 3 * current_non_nil_precommitted > 2 * total_voting_power
+            || 3 * current_nil_precommitted > 2 * total_voting_power
         {
             assertion_check(&return_responses);
             return return_responses;
         }
         if favor {
-            let event = ConsensusEvent::Precommit {
+            let event = ConsensusEvent::NonNilPrecommit {
                 proposal,
                 signer,
                 round,
@@ -124,7 +124,7 @@ pub fn precommits(
             };
             let response = state.progress(event);
             return_responses.push(response);
-            current_precommitted += power;
+            current_non_nil_precommitted += power;
         } else {
             let event = ConsensusEvent::NilPrecommit {
                 signer,
@@ -133,7 +133,7 @@ pub fn precommits(
             };
             let response = state.progress(event);
             return_responses.push(response);
-            current_nilcommitted += power;
+            current_nil_precommitted += power;
         }
     }
     assertion_check(&return_responses);
@@ -172,7 +172,7 @@ pub fn bulk_prevote(
     for i in 0..idx {
         let signer = signers[i];
         let time = timestamps[i];
-        let event = ConsensusEvent::Prevote {
+        let event = ConsensusEvent::NonNilPrevote {
             proposal,
             signer,
             round,
@@ -228,7 +228,7 @@ pub fn bulk_precommit(
     for i in 0..idx {
         let signer = signers[i];
         let time = timestamps[i];
-        let event = ConsensusEvent::Precommit {
+        let event = ConsensusEvent::NonNilPrecommit {
             proposal,
             signer,
             round,


### PR DESCRIPTION
> In vetomint/src/lib.rs, I modified (It is clear to modify)

```
ConsensusEvent::Prevote -> ConsensusEvent::NonNilPrevote

ConsensusEvent::Precommit -> ConsensusEvent::NonNilPrecommit

ConsensusResponse::BroadcastPrevote -> BroadcastNonNilPrevote

ConsensusResponse::BroadcastPrecommit -> BroadcastNonNilPrecommit
```

> In vetomint/src/progress.rs, I modified those functions
As "favor" means agree on the "proposal", It is better to change "favor" to "non-nil" in prevote/precommit step.
"favor" goes well with the meaning of broadcast, "non-nil" goes well with the meaning of receiving. 
```
on_4f_favor_prevote_propose -> on_4f_non_nil_prevote_in_propose_step

> When node receives 4f non-nil prevotes in propose step.

on_4f_favor_prevote_prevote  -> on_4f_non_nil_prevote_in_prevote_step

> When node receives 4f non-nil prevotes in prevote step.

on_4f_favor_precommit  -> on_4f_non_nil_precommit

> When node receives 4f non nil precommits in any step.

```

> In vetomint/tests/unit_actions.rs, I modified those values

```
current_prevoted-> current_non_nil_prevoted
current_nilvoted -> current_nil_prevoted
current_voted -> current_prevoted

current_precommitted -> current_non_nil_precommitted
current_nilcommitted -> current_nil_precommitted
(no total votes in precommit phase)
```
+) modified some typos in consensus/src/lib.rs
+) In vetomint/src/lib.rs, there is "prevotes_favor" which indicates BtreeMap of 
<proposal value, vote power>. 
It stores non_nil_prevotes. So we can modify it as "prevotes_favor"->"non_nil_prevotes_store". 
However, I think modifying it likely to make it more complicated. So I left it at that.  