### PR TITLE
Update interface of RawRepository

### DIFF
--- a/network/src/gossip/mod.rs
+++ b/network/src/gossip/mod.rs
@@ -1,0 +1,36 @@
+use crate::{primitives::*, *};
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+
+#[derive(Debug)]
+pub struct DummyGossipNetwork;
+
+#[async_trait]
+impl GossipNetwork for DummyGossipNetwork {
+    async fn broadcast(
+        _config: &NetworkConfig,
+        _known_peers: &[Peer],
+        _message: Vec<u8>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn serve(
+        _config: NetworkConfig,
+        _peers: SharedKnownPeers,
+    ) -> Result<
+        (
+            mpsc::Receiver<Vec<u8>>,
+            tokio::task::JoinHandle<Result<(), Error>>,
+        ),
+        Error,
+    > {
+        let (send, recv) = mpsc::channel(1);
+        let task = tokio::spawn(async move {
+            let _send = send;
+            tokio::time::sleep(std::time::Duration::MAX).await;
+            Ok(())
+        });
+        Ok((recv, task))
+    }
+}

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -77,6 +77,3 @@ pub trait PeerDiscovery {
     /// Reads the known peers from the storage.
     async fn read_known_peers(storage_directory: &str) -> Result<Vec<Peer>, Error>;
 }
-
-// TODO: remove this
-pub trait AuthorizedNetwork: Send + Sync {}

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod dms;
+pub mod gossip;
 mod peer_discovery;
 pub mod primitives;
 pub mod storage;

--- a/network/src/storage.rs
+++ b/network/src/storage.rs
@@ -89,6 +89,48 @@ impl Drop for StorageImpl {
     }
 }
 
+/// TODO: implement it
+#[derive(Debug)]
+pub struct InMemoryStorage {}
+
+#[async_trait]
+impl Storage for InMemoryStorage {
+    async fn create(_storage_directory: &str) -> Result<(), StorageError> {
+        Ok(())
+    }
+
+    async fn open(_storage_directory: &str) -> Result<Self, StorageError>
+    where
+        Self: Sized,
+    {
+        Ok(Self {})
+    }
+
+    async fn list_files(&self) -> Result<Vec<String>, StorageError> {
+        Ok(vec![])
+    }
+
+    async fn add_or_overwrite_file(
+        &mut self,
+        _name: &str,
+        _content: String,
+    ) -> Result<(), StorageError> {
+        Ok(())
+    }
+
+    async fn read_file(&self, _name: &str) -> Result<String, StorageError> {
+        Ok("".to_owned())
+    }
+
+    async fn remove_file(&mut self, _name: &str) -> Result<(), StorageError> {
+        Ok(())
+    }
+
+    async fn remove_all_files(&mut self) -> Result<(), StorageError> {
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/repository/src/format.rs
+++ b/repository/src/format.rs
@@ -9,7 +9,7 @@ pub fn to_semantic_commit(commit: &Commit, last_header: &BlockHeader) -> Semanti
             SemanticCommit {
                 title,
                 body,
-                reserved_state: None,
+                diff: Diff::None,
             }
         }
         _ => todo!(),

--- a/repository/src/lib.rs
+++ b/repository/src/lib.rs
@@ -9,7 +9,10 @@ use serde::{Deserialize, Serialize};
 use simperby_common::reserved::ReservedState;
 use simperby_common::verify::CommitSequenceVerifier;
 use simperby_common::*;
-use simperby_network::{NetworkConfig, Peer, SharedKnownPeers};
+use simperby_network::{
+    primitives::{GossipNetwork, Storage},
+    NetworkConfig, Peer, SharedKnownPeers,
+};
 use std::fmt;
 
 pub type Branch = String;
@@ -37,8 +40,10 @@ pub type Error = anyhow::Error;
 ///
 /// - It **verifies** all the incoming changes and applies them to the local repository
 /// only if they are valid.
-pub struct DistributedRepository<T> {
+pub struct DistributedRepository<N: GossipNetwork, S: Storage, T: RawRepository<N, S>> {
     raw: T,
+    _marker1: std::marker::PhantomData<N>,
+    _marker2: std::marker::PhantomData<S>,
 }
 
 fn get_timestamp() -> Timestamp {
@@ -47,7 +52,7 @@ fn get_timestamp() -> Timestamp {
     since_the_epoch.as_millis() as Timestamp
 }
 
-impl<T: RawRepository> DistributedRepository<T> {
+impl<N: GossipNetwork, S: Storage, T: RawRepository<N, S>> DistributedRepository<N, S, T> {
     pub async fn new(_raw: T) -> Result<Self, Error> {
         unimplemented!()
     }

--- a/repository/src/raw.rs
+++ b/repository/src/raw.rs
@@ -30,13 +30,12 @@ impl From<git2::Error> for Error {
     }
 }
 
-/// A commit without any diff on non-reserved area.
+/// A commit without information of diff on non-reserved area.
 #[derive(Debug, Clone)]
 pub struct SemanticCommit {
     pub title: String,
     pub body: String,
-    /// (If this commit made any change) the new reserved state.
-    pub reserved_state: Option<ReservedState>,
+    pub diff: Diff,
 }
 
 #[async_trait]

--- a/repository/src/raw.rs
+++ b/repository/src/raw.rs
@@ -211,6 +211,11 @@ pub trait RawRepository<N: GossipNetwork, S: Storage>: Send + Sync + 'static {
     async fn list_remote_tracking_branches(
         &self,
     ) -> Result<Vec<(String, String, CommitHash)>, Error>;
+
+    /// Serves a read-only Git server using `git daemon`.
+    async fn serve(self, port: u16) -> Result<tokio::task::JoinHandle<Result<(), Error>>, Error>
+    where
+        Self: Sized;
 }
 
 impl<N: GossipNetwork, S: Storage> fmt::Debug for RawRepositoryImplInner<N, S> {
@@ -840,6 +845,13 @@ impl<N: GossipNetwork, S: Storage> RawRepository<N, S> for RawRepositoryImpl<N, 
     async fn list_remote_tracking_branches(
         &self,
     ) -> Result<Vec<(String, String, CommitHash)>, Error> {
+        unimplemented!()
+    }
+
+    async fn serve(self, port: u16) -> Result<tokio::task::JoinHandle<Result<(), Error>>, Error>
+    where
+        Self: Sized,
+    {
         unimplemented!()
     }
 }


### PR DESCRIPTION
The reason that it needs to take DMS

1. Commit propagation will be performed by DMS in future, anyway
2. We need a lock mechanism for the repo, which is already implemented in DMS
3. It's natural that repo is abstracted over storage and network.