### PR TITLE
Add VetoRound for vetomint

### DIFF
--- a/vetomint/src/lib.rs
+++ b/vetomint/src/lib.rs
@@ -41,6 +41,8 @@ pub enum ConsensusEvent {
         /// Whether this node is in favor of the proposal.
         favor: bool,
     },
+    /// Informs that the node wants to skip the specific round regardless of proposals (which may even not exist).
+    SkipRound { round: Round, time: Timestamp },
     /// Updates the block candidate in which this nodes wants to propose
     BlockCandidateUpdated {
         proposal: BlockIdentifier,
@@ -82,6 +84,7 @@ impl ConsensusEvent {
         match self {
             ConsensusEvent::Start { time, .. } => *time,
             ConsensusEvent::BlockProposalReceived { time, .. } => *time,
+            ConsensusEvent::SkipRound { time, .. } => *time,
             ConsensusEvent::BlockCandidateUpdated { time, .. } => *time,
             ConsensusEvent::NonNilPrevote { time, .. } => *time,
             ConsensusEvent::NonNilPrecommit { time, .. } => *time,

--- a/vetomint/src/progress.rs
+++ b/vetomint/src/progress.rs
@@ -50,6 +50,7 @@ pub(super) fn progress(
                 };
                 expected_response
             }
+            ConsensusEvent::SkipRound { .. } => unimplemented!(),
             // Time-trigger events are handled later
             ConsensusEvent::Timer { .. } => Vec::new(),
             ConsensusEvent::NonNilPrevote {


### PR DESCRIPTION
Currently the Vetomint interface has no way to veto a round, which is required when there is no proposal for the round. (It's possible to veto a specific proposal though)