### PR TITLE
Implement `Consensus` module

### DIFF
--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -15,5 +15,5 @@ log = "0.4"
 thiserror = "1.0.32"
 simperby-common = { version = "0.0.0", path = "../common" }
 simperby-network = { version = "0.0.0", path = "../network" }
-vetomint = { version = "0.0.0", path = "../vetomint" }
+vetomint2 = { version = "0.0.0", path = "../vetomint2" }
 parking_lot = "0.12.1"


### PR DESCRIPTION
Minor todos are left:
  - ~`valid_round` needs to be provided. (#137)~
    - Fixed: By #175 
  - ~Vetomint instance needs an interface with which the node can notify that it wants to 'veto the round'. (#142)~
    - Fixed: Merged into main