### PR TITLE
Update Diff variants

### DIFF
--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -71,18 +71,24 @@ pub struct AgendaProof {
     pub proof: Vec<TypedSignature<Agenda>>,
 }
 
+/// An abstracted diff of the state.
+///
+/// - The actual content of the diff (for the non-reserved state)
+/// is not cared by the Simperby node. It only keeps the hash of it.
+/// - It holds the reserved state as a `Box` to flatten the variant size.
+/// (see https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant)
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub enum Diff {
     /// Nothing changed in the repository; an empty commit.
     None,
-    /// Only changes non-reserved areas. Contains the hash of the diff.
+    /// Changes the reserved area ONLY.
+    Reserved(Box<ReservedState>),
+    /// Changes the non-reserved area ONLY.
     ///
-    /// The actual content of the diff is not covered by this crate; see `simperby-repository`.
-    General(Hash256),
-    /// Changes the reserved area. Contains the new reserved state and the hash of the diff.
-    /// It holds the reserved state as a `Box` to flatten the variant size.
-    /// (see https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant)
-    Reserved(Box<ReservedState>, Hash256),
+    /// It contains the hash of the diff.
+    NonReserved(Hash256),
+    /// General diff that may change both the reserved state and the non-reserved state.
+    General(Box<ReservedState>, Hash256),
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]

--- a/common/src/verify.rs
+++ b/common/src/verify.rs
@@ -180,7 +180,7 @@ impl CommitSequenceVerifier {
             }
             (Commit::Transaction(tx), Phase::Block) => {
                 // Update reserved_state for reserved-diff transactions.
-                if let Diff::Reserved(rs, _) = &tx.diff {
+                if let Diff::Reserved(rs) = &tx.diff {
                     self.reserved_state = *rs.clone();
                 }
                 self.phase = Phase::Transaction {
@@ -203,7 +203,7 @@ impl CommitSequenceVerifier {
                     )));
                 }
                 // Update reserved_state for reserved-diff transactions.
-                if let Diff::Reserved(rs, _) = &tx.diff {
+                if let Diff::Reserved(rs) = &tx.diff {
                     self.reserved_state = *rs.clone();
                 }
                 preceding_transactions.push(last_transaction.clone());
@@ -461,7 +461,7 @@ mod test {
                 "recipient": "<key:some-addr-in-ethereum>",
             }))
             .unwrap(),
-            diff: Diff::General(Hash256::hash("The actual content of the diff".as_bytes())),
+            diff: Diff::NonReserved(Hash256::hash("The actual content of the diff".as_bytes())),
         })
     }
 
@@ -481,19 +481,12 @@ mod test {
             consensus_delegations: None,
         });
         reserved_state.consensus_leader_order.push(3);
-        let diff: String = serde_json::to_string(&json!({
-            "public_key": validator_keypair.last().unwrap().0,
-            "consensus_voting_power": 1,
-            "governance_voting_power": 1,
-            "delegation": null,
-        }))
-        .unwrap();
         Commit::Transaction(Transaction {
             author: validator_keypair[2].0.clone(),
             timestamp: time,
             head: "Test reserved-diff commit".to_string(),
-            body: diff.clone(),
-            diff: Diff::Reserved(Box::new(reserved_state.clone()), diff.to_hash256()),
+            body: String::new(),
+            diff: Diff::Reserved(Box::new(reserved_state.clone())),
         })
     }
 

--- a/repository/src/raw/mod.rs
+++ b/repository/src/raw/mod.rs
@@ -112,6 +112,8 @@ pub trait RawRepository: Send + Sync + 'static {
     ) -> Result<CommitHash, Error>;
 
     /// Creates a semantic commit from the currently checked out branch.
+    ///
+    /// It fails if the `diff` is not `Diff::Reserved` or `Diff::None`.
     async fn create_semantic_commit(&mut self, commit: SemanticCommit)
         -> Result<CommitHash, Error>;
 


### PR DESCRIPTION
It is important to distinguish the 'rs-only' case, which might be directly created by the node (extra-agenda txes)