### PR TITLE
Add `height` field in `Agenda` and `AgendaProof`

### DIFF
--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -55,6 +55,7 @@ pub struct BlockHeader {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct Agenda {
+    pub height: BlockHeight,
     pub author: PublicKey,
     pub timestamp: Timestamp,
     pub hash: Hash256,
@@ -67,6 +68,7 @@ pub struct ChatLog {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct AgendaProof {
+    pub height: BlockHeight,
     pub agenda_hash: Hash256,
     pub proof: Vec<TypedSignature<Agenda>>,
 }

--- a/common/src/verify.rs
+++ b/common/src/verify.rs
@@ -232,6 +232,14 @@ impl CommitSequenceVerifier {
                 *last_transaction = tx.clone();
             }
             (Commit::Agenda(agenda), Phase::Block) => {
+                // Check if agenda is associated with the current block sequence.
+                if agenda.height != self.header.height + 1 {
+                    return Err(Error::InvalidArgument(format!(
+                        "invalid agenda block height: expected {}, got {}",
+                        self.header.height + 1,
+                        agenda.height
+                    )));
+                }
                 // Verify agenda without transactions
                 if agenda.hash != Agenda::calculate_hash(self.header.height, &[]) {
                     return Err(Error::InvalidArgument(format!(
@@ -251,6 +259,14 @@ impl CommitSequenceVerifier {
                     preceding_transactions,
                 },
             ) => {
+                // Check if agenda is associated with the current block sequence.
+                if agenda.height != self.header.height + 1 {
+                    return Err(Error::InvalidArgument(format!(
+                        "invalid agenda block height: expected {}, got {}",
+                        self.header.height + 1,
+                        agenda.height
+                    )));
+                }
                 // Check if agenda is in chronological order
                 if agenda.timestamp < last_transaction.timestamp {
                     return Err(Error::InvalidArgument(
@@ -275,6 +291,14 @@ impl CommitSequenceVerifier {
                 };
             }
             (Commit::AgendaProof(agenda_proof), Phase::Agenda { agenda }) => {
+                // Check if agenda proof is associated with the current block sequence.
+                if agenda_proof.height != self.header.height + 1 {
+                    return Err(Error::InvalidArgument(format!(
+                        "invalid agenda proof block height: expected {}, got {}",
+                        self.header.height + 1,
+                        agenda_proof.height
+                    )));
+                }
                 // Check if agenda hash matches
                 if agenda_proof.agenda_hash != agenda.hash {
                     return Err(Error::InvalidArgument(format!(
@@ -528,6 +552,7 @@ mod test {
         Commit::AgendaProof(AgendaProof {
             agenda_hash: agenda_hash_value,
             proof: agenda_proof,
+            height: agenda.height,
         })
     }
 
@@ -639,6 +664,7 @@ mod test {
             author: validator_keypair[0].0.clone(),
             timestamp: 4,
             hash: agenda_hash_value,
+            height: csv.header.height + 1,
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -660,6 +686,7 @@ mod test {
             author: validator_keypair[0].0.clone(),
             timestamp: 1,
             hash: agenda_hash_value,
+            height: csv.header.height + 1,
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -681,6 +708,7 @@ mod test {
             author: validator_keypair[0].0.clone(),
             timestamp: 1,
             hash: agenda_hash_value,
+            height: csv.header.height + 1,
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -721,6 +749,7 @@ mod test {
             author: validator_keypair[0].0.clone(),
             timestamp: 1,
             hash: agenda_hash_value,
+            height: csv.header.height + 1,
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -761,6 +790,7 @@ mod test {
             author: validator_keypair[0].0.clone(),
             timestamp: 1,
             hash: agenda_hash_value,
+            height: csv.header.height + 1,
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -801,6 +831,7 @@ mod test {
             author: validator_keypair[0].0.clone(),
             timestamp: 1,
             hash: agenda_hash_value,
+            height: csv.header.height + 1,
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -841,6 +872,7 @@ mod test {
             author: validator_keypair[0].0.clone(),
             timestamp: 1,
             hash: agenda_hash_value,
+            height: csv.header.height + 1,
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -884,6 +916,7 @@ mod test {
             author: validator_keypair[0].0.clone(),
             timestamp: 1,
             hash: agenda_hash_value,
+            height: csv.header.height + 1,
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -927,6 +960,7 @@ mod test {
             author: validator_keypair[0].0.clone(),
             timestamp: 1,
             hash: agenda_hash_value,
+            height: csv.header.height + 1,
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -1019,6 +1053,7 @@ mod test {
             author: validator_keypair[0].0.clone(),
             timestamp: 4,
             hash: agenda_hash_value,
+            height: csv.header.height + 1,
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply block commit at agenda phase
@@ -1061,6 +1096,7 @@ mod test {
             author: validator_keypair[0].0.clone(),
             timestamp: 1,
             hash: agenda_hash_value,
+            height: csv.header.height + 1,
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply transaction commit at agenda phase
@@ -1078,6 +1114,7 @@ mod test {
             author: validator_keypair[0].0.clone(),
             timestamp: 1,
             hash: agenda_hash_value,
+            height: csv.header.height + 1,
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -1110,6 +1147,7 @@ mod test {
             author: validator_keypair[0].0.clone(),
             timestamp: 1,
             hash: agenda_hash_value,
+            height: csv.header.height + 1,
         };
         csv.apply_commit(&generate_agenda_commit(&agenda))
             .unwrap_err();
@@ -1128,6 +1166,7 @@ mod test {
             author: validator_keypair[0].0.clone(),
             timestamp: 2,
             hash: agenda_hash_value,
+            height: csv.header.height + 1,
         };
         csv.apply_commit(&generate_agenda_commit(&agenda))
             .unwrap_err();
@@ -1145,6 +1184,7 @@ mod test {
             author: validator_keypair[0].0.clone(),
             timestamp: 0,
             hash: Agenda::calculate_hash(csv.header.height, &[]),
+            height: csv.header.height + 1,
         };
         csv.apply_commit(&generate_agenda_commit(&agenda))
             .unwrap_err();
@@ -1160,6 +1200,7 @@ mod test {
             author: validator_keypair[0].0.clone(),
             timestamp: 1,
             hash: agenda_hash_value,
+            height: csv.header.height + 1,
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda commit again
@@ -1177,6 +1218,7 @@ mod test {
             author: validator_keypair[0].0.clone(),
             timestamp: 1,
             hash: agenda_hash_value,
+            height: csv.header.height + 1,
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -1203,6 +1245,7 @@ mod test {
             author: validator_keypair[0].0.clone(),
             timestamp: 1,
             hash: agenda_hash_value,
+            height: csv.header.height + 1,
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit with invalid agenda hash
@@ -1224,6 +1267,7 @@ mod test {
             author: validator_keypair[0].0.clone(),
             timestamp: 1,
             hash: agenda_hash_value,
+            height: csv.header.height + 1,
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit with invalid signature
@@ -1233,6 +1277,7 @@ mod test {
                 author: validator_keypair[1].0.clone(),
                 timestamp: 0,
                 hash: Hash256::zero(),
+                height: csv.header.height + 1,
             },
             agenda_hash_value,
         ))
@@ -1249,6 +1294,7 @@ mod test {
             author: validator_keypair[0].0.clone(),
             timestamp: 1,
             hash: agenda_hash_value,
+            height: csv.header.height + 1,
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -1280,6 +1326,7 @@ mod test {
             author: validator_keypair[0].0.clone(),
             timestamp: 2,
             hash: agenda_hash_value,
+            height: csv.header.height + 1,
         };
         csv.apply_commit(&generate_agenda_proof_commit(
             &validator_keypair,
@@ -1301,6 +1348,7 @@ mod test {
             author: validator_keypair[0].0.clone(),
             timestamp: 1,
             hash: agenda_hash_value,
+            height: csv.header.height + 1,
         };
         csv.apply_commit(&generate_agenda_proof_commit(
             &validator_keypair,

--- a/common/src/verify.rs
+++ b/common/src/verify.rs
@@ -1132,6 +1132,23 @@ mod test {
     // TODO: add test case where the transaction commit is invalid because it is extra-agenda transaction phase.
 
     #[test]
+    /// Test the case where the agenda commit is invalid because the agenda height is invalid.
+    /// The agenda height should be the next height of the last header height.
+    fn invalid_agenda_commit_with_invalid_height() {
+        let (validator_keypair, _, mut csv) = setup_test(3);
+        // Apply agenda commit with invalid height
+        let agenda_hash_value = calculate_agenda_hash(csv.phase.clone(), csv.header.height);
+        let agenda: Agenda = Agenda {
+            author: validator_keypair[0].0.clone(),
+            timestamp: 1,
+            hash: agenda_hash_value,
+            height: 0,
+        };
+        csv.apply_commit(&generate_agenda_commit(&agenda))
+            .unwrap_err();
+    }
+
+    #[test]
     /// Test the case where the agenda commit is invalid because the agenda hash is invalid.
     fn invalid_agenda_commit_with_invalid_agenda_hash1() {
         let (validator_keypair, _, mut csv) = setup_test(3);
@@ -1234,6 +1251,34 @@ mod test {
     }
 
     // TODO: add test case where the agenda commit is invalid because it is extra-agenda transaction phase.
+
+    #[test]
+    /// Test the case where the agenda proof commit is invalid because the agenda proof height is invalid.
+    /// The agenda proof height should be the next height of the last header height.
+    fn invalid_agenda_proof_commit_with_invalid_height() {
+        let (validator_keypair, _, mut csv) = setup_test(3);
+        // Apply agenda commit
+        let agenda_hash_value = calculate_agenda_hash(csv.phase.clone(), csv.header.height);
+        let agenda: Agenda = Agenda {
+            author: validator_keypair[0].0.clone(),
+            timestamp: 1,
+            hash: agenda_hash_value,
+            height: csv.header.height + 1,
+        };
+        csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
+        // Apply agenda-proof commit with invalid height
+        csv.apply_commit(&generate_agenda_proof_commit(
+            &validator_keypair,
+            &Agenda {
+                author: validator_keypair[1].0.clone(),
+                timestamp: 1,
+                hash: agenda_hash_value,
+                height: 0,
+            },
+            agenda_hash_value,
+        ))
+        .unwrap_err();
+    }
 
     #[test]
     /// Test the case where the agenda proof commit is invalid because the agenda hash is invalid.

--- a/repository/src/lib.rs
+++ b/repository/src/lib.rs
@@ -291,6 +291,7 @@ impl<T: RawRepository> DistributedRepository<T> {
             author,
             timestamp: get_timestamp(),
             hash: Agenda::calculate_hash(last_header.height + 1, &transactions),
+            height: last_header.height + 1,
         });
         let semantic_commit = to_semantic_commit(&agenda_commit, &last_header);
 


### PR DESCRIPTION
For three reasons
1. Looks better
2. Safety with cheap resource
3. (Important) message in DMS must have information on block height. There exists `hash` in `Agenda` but it can consist of replayable contents due to the characteristic of `Commit`. So we need to prevent this.

