### PR TITLE
Update `query_commit_path` to not include `ancestor`

### DIFF
--- a/repository/src/raw/mod.rs
+++ b/repository/src/raw/mod.rs
@@ -163,7 +163,8 @@ pub trait RawRepository: Send + Sync + 'static {
         max: Option<usize>,
     ) -> Result<Vec<CommitHash>, Error>;
 
-    /// Queries the commits from `ancestor` to `descendant`, including both.
+    /// Queries the commits from the very next commit of `ancestor` to `descendant`.
+    /// `ancestor` not included, `descendant` included.
     ///
     /// It fails if the `ancestor` is not the merge base of the two commits.
     async fn query_commit_path(

--- a/repository/src/raw/mod.rs
+++ b/repository/src/raw/mod.rs
@@ -166,6 +166,7 @@ pub trait RawRepository: Send + Sync + 'static {
     /// Queries the commits from the very next commit of `ancestor` to `descendant`.
     /// `ancestor` not included, `descendant` included.
     ///
+    /// It fails if the two commits are the same.
     /// It fails if the `ancestor` is not the merge base of the two commits.
     async fn query_commit_path(
         &self,


### PR DESCRIPTION
for all implementation of distributed repository using `query_commit_path`, commit path from the very next commit of `ancestor` to `descendant` is needed

so if both `ancestor` and `descendant` is included, the implementation gets messy needing to do `commits.remove(0)` every time

also we already know the `ancestor`, so i think this update is reasonable