### PR TITLE
Rename relay to serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Simperby is a blockchain engine that provides
 4. **Git Repository**: a distributed Git repository that every member can fetch and verify, and also can push commits with governance approval.
 
 Also, Simperby is provided as an **extremely lightweight CLI** software.
-It *does NOT run in the background*. All the operations except `simperby update` and `simperby relay` are done *synchronously and explicitly* (i.e. performs the given operation and returns the result immediately).
+It *does NOT run in the background*. All the operations except `simperby run` and `simperby serve` are done *synchronously and explicitly* (i.e. performs the given operation and returns the result immediately).
 
 ## DAO
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -95,7 +95,7 @@ pub enum Commands {
     },
     /// Show the overall information of the given commit.
     Show { commit: String },
-    /// Run the Simperby node indefinitely. This is same as running `relay` while
+    /// Run the Simperby node indefinitely. This is same as running `serve` while
     /// invoking `consensus` and `fetch` repeatedly.
     Run,
     /// Make a progress on the consensus.
@@ -112,8 +112,8 @@ pub enum Commands {
     },
     /// Show the current status of the p2p network.
     Network,
-    /// Serve the gossip protocol indefinitely, relaying the incoming packets to other peers.
-    Relay,
+    /// Serve the p2p network indefinitely.
+    Serve,
     /// Fetch the data broadcasted over the network and update it to the repository,
     /// the governance, and the consensus.
     Fetch,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -15,7 +15,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::Create(CreateCommands::Block) => todo!(),
         Commands::Show { commit } => show(commit).await?,
         Commands::Consensus { show: _ } => todo!(),
-        Commands::Relay => todo!(),
+        Commands::Serve => todo!(),
         Commands::Fetch => todo!(),
         _ => unimplemented!(),
     }

--- a/network/src/primitives.rs
+++ b/network/src/primitives.rs
@@ -60,7 +60,7 @@ pub trait GossipNetwork: Send + Sync + 'static {
     ) -> Result<(), Error>;
 
     /// Remains online on the network indefinitely,
-    /// relaying (propagating) messages broadcasted over the network.
+    /// serving (propagating) messages broadcasted over the network.
     async fn serve(
         config: NetworkConfig,
         peers: SharedKnownPeers,

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -105,8 +105,8 @@ pub trait SimperbyApi {
     /// Gets the current status of the p2p network.
     async fn get_network_status(&self) -> Result<NetworkStatus>;
 
-    /// Serves indefinitely relaying network messages.
-    async fn relay(self) -> Result<()>;
+    /// Serves indefinitely the p2p network.
+    async fn serve(self) -> Result<()>;
 
     /// Fetch the data from the network and apply to the repository, the governance, and the consensus.
     async fn fetch(&mut self) -> Result<()>;

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -128,7 +128,7 @@ impl<N: GossipNetwork, S: Storage, R: RawRepository> SimperbyApi for Node<N, S, 
         unimplemented!()
     }
 
-    async fn relay(self) -> Result<()> {
+    async fn serve(self) -> Result<()> {
         todo!()
     }
 


### PR DESCRIPTION
The term 'relay' is reserved for multichain message delivery