### PR TITLE
Implement the rest of `clean`

### DIFF
--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -162,8 +162,8 @@ impl SimperbyNode {
     }
 
     /// Cleans the repository, removing all the outdated commits.
-    pub async fn clean(&mut self, _hard: bool) -> Result<()> {
-        self.repository.clean().await
+    pub async fn clean(&mut self, hard: bool) -> Result<()> {
+        self.repository.clean(hard).await
     }
 
     /// Creates a block commit on the `work` branch.


### PR DESCRIPTION
- [x] Clean invalid branches using CSV
- [x] Implement hard option
- [x] Update comments
- [x] Fix using utils

This PR wraps up the unfinished implementation of `clean` method