### PR TITLE
Introduce binary en/decoding

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,6 +12,7 @@ rand = { version = "0.7" }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 hex = "0.4.3"
 secp256k1 = { version = "0.24.2", features = ["recovery", "rand-std"] }
+bincode = "1.3.3"
 
 [dev-dependencies]
 simperby-test-suite = { path = "../test-suite" }

--- a/common/src/crypto.rs
+++ b/common/src/crypto.rs
@@ -3,7 +3,7 @@ use secp256k1::{
     ecdsa::{RecoverableSignature, RecoveryId},
     Message, Secp256k1, SecretKey,
 };
-use serde::{Deserialize, Serialize};
+use serde::{ser::SerializeTuple, Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 use std::fmt;
 use thiserror::Error;
@@ -41,7 +41,15 @@ impl<const N: usize> Serialize for HexSerializedBytes<N> {
     where
         S: serde::ser::Serializer,
     {
-        serializer.serialize_str(hex::encode(self.data).as_str())
+        if serializer.is_human_readable() {
+            serializer.serialize_str(hex::encode(self.data).as_str())
+        } else {
+            let mut seq = serializer.serialize_tuple(N)?;
+            for e in self.data {
+                seq.serialize_element(&e)?;
+            }
+            seq.end()
+        }
     }
 }
 

--- a/common/src/hash.rs
+++ b/common/src/hash.rs
@@ -165,7 +165,7 @@ mod tests {
             version,
         };
 
-        // note that `header` is from `simperby-test-suite`, which is not compatible with
+        // Note that `header` is from `simperby-test-suite`, which is not compatible with
         // this crate. Thus we compare the strings.
         assert_eq!(
             serde_spb::to_string(&header).unwrap(),

--- a/common/src/hash.rs
+++ b/common/src/hash.rs
@@ -105,3 +105,71 @@ impl BlockHeader {
 
     // note that `repository_merkle_root` is calculated from `simperby-repository`.
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde_spb;
+    use std::mem::size_of;
+
+    unsafe fn read<T: Clone>(offset: &mut usize, data: &[u8]) -> T {
+        let size = size_of::<T>();
+        let p = data[*offset..*offset + size].as_ptr() as *const T;
+        let x = (*p).clone();
+        *offset += size;
+        x
+    }
+
+    #[test]
+    fn decode_header() {
+        let header = simperby_test_suite::generate_standard_genesis(5)
+            .0
+            .genesis_info
+            .header;
+        let encoded = serde_spb::to_vec(&header).unwrap();
+
+        let mut offset = 0;
+
+        let author = unsafe { read::<PublicKey>(&mut offset, &encoded) };
+        let prev_block_finalization_proof_len = unsafe { read::<usize>(&mut offset, &encoded) };
+        let mut prev_block_finalization_proof = Vec::new();
+        for _ in 0..prev_block_finalization_proof_len {
+            prev_block_finalization_proof
+                .push(unsafe { read::<TypedSignature<BlockHeader>>(&mut offset, &encoded) });
+        }
+        let previous_hash = unsafe { read::<Hash256>(&mut offset, &encoded) };
+        let height = unsafe { read::<BlockHeight>(&mut offset, &encoded) };
+        let timestamp = unsafe { read::<Timestamp>(&mut offset, &encoded) };
+        let commit_merkle_root = unsafe { read::<Hash256>(&mut offset, &encoded) };
+        let repository_merkle_root = unsafe { read::<Hash256>(&mut offset, &encoded) };
+        let validator_set_len = unsafe { read::<usize>(&mut offset, &encoded) };
+        let mut validator_set = Vec::new();
+        for _ in 0..validator_set_len {
+            let pub_key = unsafe { read::<PublicKey>(&mut offset, &encoded) };
+            let voting_power = unsafe { read::<VotingPower>(&mut offset, &encoded) };
+            validator_set.push((pub_key, voting_power));
+        }
+        offset += 8; // skip version length (it's always 5)
+        let version = unsafe { read::<[u8; 5]>(&mut offset, &encoded) };
+        let version = String::from_utf8(version.to_vec()).unwrap();
+
+        let header_decoded = BlockHeader {
+            author,
+            prev_block_finalization_proof,
+            previous_hash,
+            height,
+            timestamp,
+            commit_merkle_root,
+            repository_merkle_root,
+            validator_set,
+            version,
+        };
+
+        // note that `header` is from `simperby-test-suite`, which is not compatible with
+        // this crate. Thus we compare the strings.
+        assert_eq!(
+            serde_spb::to_string(&header).unwrap(),
+            serde_spb::to_string(&header_decoded).unwrap()
+        );
+    }
+}

--- a/common/src/serde_spb.rs
+++ b/common/src/serde_spb.rs
@@ -9,10 +9,10 @@ pub fn from_str<T: DeserializeOwned>(s: &str) -> Result<T, Error> {
     serde_json::from_str(s)
 }
 
-pub fn to_vec<T: Serialize>(t: &T) -> Result<Vec<u8>, Error> {
-    serde_json::to_vec_pretty(t)
+pub fn to_vec<T: Serialize>(t: &T) -> Result<Vec<u8>, bincode::Error> {
+    bincode::serialize(t)
 }
 
-pub fn from_slice<T: DeserializeOwned>(s: &[u8]) -> Result<T, Error> {
-    serde_json::from_slice(s)
+pub fn from_slice<T: DeserializeOwned>(s: &[u8]) -> Result<T, bincode::Error> {
+    bincode::deserialize_from(s)
 }

--- a/node/tests/integration_tests.rs
+++ b/node/tests/integration_tests.rs
@@ -23,7 +23,7 @@ async fn setup_peer(path: &str, peers: &[Peer]) {
     let mut file = tokio::fs::File::create(format!("{path}/peers.json"))
         .await
         .unwrap();
-    file.write_all(&serde_spb::to_vec(&peers).unwrap())
+    file.write_all(serde_spb::to_string(&peers).unwrap().as_bytes())
         .await
         .unwrap();
     file.flush().await.unwrap();


### PR DESCRIPTION
1. We now use bincode format for binary en/decoding. Note that **this determines how to hash and sign the core types**.
2. I added a simple guide to manually decoding a bincode-encoded data type. You will find this very useful for implementing the light client.

Please refer to [the spec](https://github.com/bincode-org/bincode/blob/trunk/docs/spec.md) for details.