### PR TITLE
Update commit author/timestamp

### DIFF
--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -60,7 +60,7 @@ pub struct BlockHeader {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct Agenda {
     pub height: BlockHeight,
-    pub author: PublicKey,
+    pub author: MemberName,
     pub timestamp: Timestamp,
     pub transactions_hash: Hash256,
 }
@@ -75,6 +75,7 @@ pub struct AgendaProof {
     pub height: BlockHeight,
     pub agenda_hash: Hash256,
     pub proof: Vec<TypedSignature<Agenda>>,
+    pub timestamp: Timestamp,
 }
 
 /// An abstracted diff of the state.
@@ -97,9 +98,19 @@ pub enum Diff {
     General(Box<ReservedState>, Hash256),
 }
 
+/// A general transaction to be included in the agenda.
+///
+/// Note that none of the fields are checked by the Simperby core protocol;
+/// they just represent a Git commit which is used for general data recording.
+///
+/// - `author` and `timestamp` is that of the **author signature** of the git commit.
+/// - `committer` signature will be always the same as the `author` signature.
+/// (if not, it will be rejected by the node)
+/// - `head` and `body` might be used for the trustless message delivery.
+/// Please refer to the *simperby-settlement* crate.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct Transaction {
-    pub author: PublicKey,
+    pub author: MemberName,
     pub timestamp: Timestamp,
     pub head: String,
     pub body: String,

--- a/common/src/verify.rs
+++ b/common/src/verify.rs
@@ -692,7 +692,7 @@ mod test {
     #[test]
     /// Test the case where the commit sequence is correct.
     fn correct_commit_sequence1() {
-        let (mut validator_keypair, mut reserved_state, mut csv) = setup_test(3);
+        let (mut validator_keypair, mut reserved_state, mut csv) = setup_test(4);
         // Apply empty transaction commit
         csv.apply_commit(&generate_empty_transaction_commit())
             .unwrap();
@@ -727,7 +727,7 @@ mod test {
     #[test]
     /// Test the case where the commit sequence is correct but there are no transaction commits.
     fn correct_commit_sequence2() {
-        let (validator_keypair, reserved_state, mut csv) = setup_test(3);
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
         // Apply agenda commit
         let agenda_transactions_hash = calculate_agenda_transactions_hash(csv.phase.clone());
         let agenda: Agenda = Agenda {
@@ -749,7 +749,7 @@ mod test {
     #[test]
     /// Test the case where the block commit is invalid because the block height is invalid.
     fn invalid_block_commit_with_invalid_height() {
-        let (validator_keypair, reserved_state, mut csv) = setup_test(3);
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
         // Apply agenda commit
         let agenda_transactions_hash = calculate_agenda_transactions_hash(csv.phase.clone());
         let agenda: Agenda = Agenda {
@@ -792,7 +792,7 @@ mod test {
     #[test]
     /// Test the case where the block commit is invalid because the previous hash is invalid.
     fn invalid_block_commit_with_invalid_previous_hash() {
-        let (validator_keypair, reserved_state, mut csv) = setup_test(3);
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
         // Apply agenda commit
         let agenda_transactions_hash = calculate_agenda_transactions_hash(csv.phase.clone());
         let agenda: Agenda = Agenda {
@@ -835,7 +835,7 @@ mod test {
     #[test]
     /// Test the case where the block commit is invalid because the author is invalid.
     fn invalid_block_commit_with_invalid_author() {
-        let (validator_keypair, reserved_state, mut csv) = setup_test(3);
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
         // Apply agenda commit
         let agenda_transactions_hash = calculate_agenda_transactions_hash(csv.phase.clone());
         let agenda: Agenda = Agenda {
@@ -878,7 +878,7 @@ mod test {
     #[test]
     /// Test the case where the block commit is invalid because the timestamp is invalid.
     fn invalid_block_commit_with_invalid_timestamp() {
-        let (validator_keypair, reserved_state, mut csv) = setup_test(3);
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
         // Apply agenda commit
         let agenda_transactions_hash = calculate_agenda_transactions_hash(csv.phase.clone());
         let agenda: Agenda = Agenda {
@@ -921,7 +921,7 @@ mod test {
     #[test]
     /// Test the case where the block commit is invalid because the finalization proof is invalid for invalid signature.
     fn invalid_block_commit_with_invalid_finalization_proof_for_invalid_signature() {
-        let (validator_keypair, reserved_state, mut csv) = setup_test(3);
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
         // Apply agenda commit
         let agenda_transactions_hash = calculate_agenda_transactions_hash(csv.phase.clone());
         let agenda: Agenda = Agenda {
@@ -965,7 +965,7 @@ mod test {
     #[test]
     /// Test the case where the block commit is invalid because the finalization proof is invalid for low voting power.
     fn invalid_block_commit_with_invalid_finalization_proof_for_low_voting_power() {
-        let (validator_keypair, reserved_state, mut csv) = setup_test(3);
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
         // Apply agenda commit
         let agenda_transactions_hash = calculate_agenda_transactions_hash(csv.phase.clone());
         let agenda: Agenda = Agenda {
@@ -1011,7 +1011,7 @@ mod test {
     #[test]
     /// Test the case where the block commit is invalid because the commit merkle root is invalid.
     fn invalid_block_commit_with_invalid_commit_merkle_root() {
-        let (validator_keypair, reserved_state, mut csv) = setup_test(3);
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
         // Apply agenda commit
         let agenda_transactions_hash = calculate_agenda_transactions_hash(csv.phase.clone());
         let agenda: Agenda = Agenda {
@@ -1052,7 +1052,7 @@ mod test {
     #[test]
     /// Test the case where the block commit is invalid because block commit already exists.
     fn phase_mismatch_for_block_commit1() {
-        let (validator_keypair, _, mut csv) = setup_test(3);
+        let (validator_keypair, _, mut csv) = setup_test(4);
         // Apply block commit at block phase
         csv.apply_commit(&generate_block_commit(
             &validator_keypair,
@@ -1068,7 +1068,7 @@ mod test {
     #[test]
     /// Test the case where the block commit is invalid because it is transaction phase.
     fn phase_mismatch_for_block_commit2() {
-        let (validator_keypair, _, mut csv) = setup_test(3);
+        let (validator_keypair, _, mut csv) = setup_test(4);
         // Apply empty transaction commit
         csv.apply_commit(&generate_empty_transaction_commit())
             .unwrap();
@@ -1087,7 +1087,7 @@ mod test {
     #[test]
     /// Test the case where the block commit is invalid because it is agenda phase.
     fn phase_mismatch_for_block_commit3() {
-        let (mut validator_keypair, mut reserved_state, mut csv) = setup_test(3);
+        let (mut validator_keypair, mut reserved_state, mut csv) = setup_test(4);
         // Apply empty transaction commit
         csv.apply_commit(&generate_empty_transaction_commit())
             .unwrap();
@@ -1125,7 +1125,7 @@ mod test {
     #[test]
     /// Test the case where the transaction commit is invalid because it is agenda phase.
     fn phase_mismatch_for_transaction_commit1() {
-        let (validator_keypair, reserved_state, mut csv) = setup_test(3);
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
         // Apply agenda commit
         let agenda_transactions_hash = calculate_agenda_transactions_hash(csv.phase.clone());
         let agenda: Agenda = Agenda {
@@ -1143,7 +1143,7 @@ mod test {
     #[test]
     /// Test the case where the transaction commit is invalid because it is agenda proof phase.
     fn phase_mismatch_for_transaction_commit2() {
-        let (validator_keypair, reserved_state, mut csv) = setup_test(3);
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
         // Apply agenda commit
         let agenda_transactions_hash = calculate_agenda_transactions_hash(csv.phase.clone());
         let agenda: Agenda = Agenda {
@@ -1178,7 +1178,7 @@ mod test {
     /// Test the case where the agenda commit is invalid because the agenda height is invalid.
     /// The agenda height should be the next height of the last header height.
     fn invalid_agenda_commit_with_invalid_height() {
-        let (validator_keypair, reserved_state, mut csv) = setup_test(3);
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
         // Apply agenda commit with invalid height
         let agenda_transactions_hash = calculate_agenda_transactions_hash(csv.phase.clone());
         let agenda: Agenda = Agenda {
@@ -1194,7 +1194,7 @@ mod test {
     #[test]
     /// Test the case where the agenda commit is invalid because the agenda hash is invalid.
     fn invalid_agenda_commit_with_invalid_agenda_hash1() {
-        let (validator_keypair, reserved_state, mut csv) = setup_test(3);
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
         // Apply agenda commit with invalid agenda hash
         let agenda_transactions_hash = if let Commit::Transaction(transaction) =
             generate_empty_transaction_commit()
@@ -1216,7 +1216,7 @@ mod test {
     #[test]
     /// Test the case where the agenda commit is invalid because the agenda hash is invalid.
     fn invalid_agenda_commit_with_invalid_agenda_hash2() {
-        let (validator_keypair, reserved_state, mut csv) = setup_test(3);
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
         // Apply empty transaction commit
         csv.apply_commit(&generate_empty_transaction_commit())
             .unwrap();
@@ -1235,7 +1235,7 @@ mod test {
     #[test]
     /// Test the case where the agenda commit is invalid because the timestamp is invalid.
     fn invalid_agenda_commit_with_invalid_timestamp() {
-        let (validator_keypair, reserved_state, mut csv) = setup_test(3);
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
         // Apply empty transaction commit
         csv.apply_commit(&generate_empty_transaction_commit())
             .unwrap();
@@ -1253,7 +1253,7 @@ mod test {
     #[test]
     /// Test the case where the agenda commit is invalid because agenda commit already exists.
     fn phase_mismatch_for_agenda_commit1() {
-        let (validator_keypair, reserved_state, mut csv) = setup_test(3);
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
         // Apply agenda commit
         let agenda_transactions_hash = calculate_agenda_transactions_hash(csv.phase.clone());
         let agenda: Agenda = Agenda {
@@ -1271,7 +1271,7 @@ mod test {
     #[test]
     /// Test the case where the agenda commit is invalid because it is in agenda proof phase.
     fn phase_mismatch_for_agenda_commit2() {
-        let (validator_keypair, reserved_state, mut csv) = setup_test(3);
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
         // Apply agenda commit
         let agenda_transactions_hash = calculate_agenda_transactions_hash(csv.phase.clone());
         let agenda: Agenda = Agenda {
@@ -1306,7 +1306,7 @@ mod test {
     /// Test the case where the agenda proof commit is invalid because the agenda proof height is invalid.
     /// The agenda proof height should be the next height of the last header height.
     fn invalid_agenda_proof_commit_with_invalid_height() {
-        let (validator_keypair, reserved_state, mut csv) = setup_test(3);
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
         // Apply agenda commit
         let agenda_transactions_hash = calculate_agenda_transactions_hash(csv.phase.clone());
         let agenda: Agenda = Agenda {
@@ -1333,7 +1333,7 @@ mod test {
     #[test]
     /// Test the case where the agenda proof commit is invalid because the agenda hash is invalid.
     fn invalid_agenda_proof_with_invalid_agenda_hash() {
-        let (validator_keypair, reserved_state, mut csv) = setup_test(3);
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
         // Apply agenda commit
         let agenda_transactions_hash = calculate_agenda_transactions_hash(csv.phase.clone());
         let agenda: Agenda = Agenda {
@@ -1355,7 +1355,7 @@ mod test {
     #[test]
     /// Test the case where the agenda proof commit is invalid because the signature is invalid.
     fn invalid_agenda_proof_with_invalid_signature() {
-        let (validator_keypair, reserved_state, mut csv) = setup_test(3);
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
         // Apply agenda commit
         let agenda_transactions_hash = calculate_agenda_transactions_hash(csv.phase.clone());
         let agenda: Agenda = Agenda {
@@ -1382,7 +1382,7 @@ mod test {
     #[test]
     /// Test the case where the agenda proof commit is invalid because agenda proof already exists.
     fn phase_mismatch_for_agenda_proof_commit1() {
-        let (validator_keypair, reserved_state, mut csv) = setup_test(3);
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
         // Apply agenda commit
         let agenda_transactions_hash = calculate_agenda_transactions_hash(csv.phase.clone());
         let agenda: Agenda = Agenda {
@@ -1411,7 +1411,7 @@ mod test {
     #[test]
     /// Test the case where the agenda proof commit is invalid because it is transaction phase.
     fn phase_mismatch_for_agenda_proof_commit2() {
-        let (validator_keypair, reserved_state, mut csv) = setup_test(3);
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
         // Apply empty transaction commit
         csv.apply_commit(&generate_empty_transaction_commit())
             .unwrap();
@@ -1443,7 +1443,7 @@ mod test {
     #[test]
     /// Test the case where the agenda proof commit is invalid because it is block phase.
     fn phase_mismatch_for_agenda_proof_commit4() {
-        let (validator_keypair, reserved_state, mut csv) = setup_test(3);
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
         // Apply agenda-proof commit at block phase
         let agenda_transactions_hash = calculate_agenda_transactions_hash(csv.phase.clone());
         let agenda: Agenda = Agenda {

--- a/common/tests/integration_tests.rs
+++ b/common/tests/integration_tests.rs
@@ -10,11 +10,11 @@ fn basic1() {
     let genesis_info = rs.genesis_info.clone();
     let genesis_header = rs.genesis_info.header.clone();
 
-    let mut csv = CommitSequenceVerifier::new(genesis_header.clone(), rs).unwrap();
+    let mut csv = CommitSequenceVerifier::new(genesis_header.clone(), rs.clone()).unwrap();
     let mut light_client = LightClient::new(genesis_header);
 
     let tx = Transaction {
-        author: PublicKey::zero(),
+        author: "doesn't matter".to_owned(),
         timestamp: 0,
         head: "commit 1".to_owned(),
         body: "".to_owned(),
@@ -23,7 +23,7 @@ fn basic1() {
     csv.apply_commit(&Commit::Transaction(tx.clone())).unwrap();
     let agenda = Agenda {
         height: 1,
-        author: keys[0].0.clone(),
+        author: rs.query_name(&keys[0].0).unwrap(),
         timestamp: 0,
         transactions_hash: Agenda::calculate_transactions_hash(&[tx.clone()]),
     };
@@ -35,6 +35,7 @@ fn basic1() {
             .iter()
             .map(|(_, private_key)| TypedSignature::sign(&agenda, private_key).unwrap())
             .collect::<Vec<_>>(),
+        timestamp: 0,
     }))
     .unwrap();
     let block_header = BlockHeader {
@@ -82,7 +83,7 @@ fn basic2() {
     let mut light_client = LightClient::new(genesis_header);
 
     let tx = Transaction {
-        author: PublicKey::zero(),
+        author: "doesn't matter".to_owned(),
         timestamp: 0,
         head: "commit 1".to_owned(),
         body: "".to_owned(),
@@ -91,7 +92,7 @@ fn basic2() {
     csv.apply_commit(&Commit::Transaction(tx.clone())).unwrap();
     let agenda = Agenda {
         height: 1,
-        author: keys[1].0.clone(),
+        author: reserved_state.query_name(&keys[1].0).unwrap(),
         timestamp: 0,
         transactions_hash: Agenda::calculate_transactions_hash(&[tx.clone()]),
     };
@@ -103,6 +104,7 @@ fn basic2() {
             .iter()
             .map(|(_, private_key)| TypedSignature::sign(&agenda, private_key).unwrap())
             .collect::<Vec<_>>(),
+        timestamp: 0,
     }))
     .unwrap();
     let block_header = BlockHeader {

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -184,9 +184,13 @@ impl SimperbyNode {
 
     /// Creates an agenda commit on the `work` branch.
     pub async fn create_agenda(&mut self) -> Result<CommitHash> {
+        let rs = self.repository.get_reserved_state().await?;
         let (_, commit_hash) = self
             .repository
-            .create_agenda(self.config.public_key.clone())
+            .create_agenda(
+                rs.query_name(&self.config.public_key)
+                    .expect("already checked in initialization"),
+            )
             .await?;
         Ok(commit_hash)
     }
@@ -363,6 +367,7 @@ impl SimperbyNode {
                             .iter()
                             .map(|(k, s)| TypedSignature::new(s.clone(), k.clone()))
                             .collect(),
+                        get_timestamp(),
                     )
                     .await;
             }

--- a/repository/src/lib.rs
+++ b/repository/src/lib.rs
@@ -27,6 +27,7 @@ pub const FP_BRANCH_NAME: &str = "fp";
 pub const COMMIT_TITLE_HASH_DIGITS: usize = 8;
 pub const TAG_NAME_HASH_DIGITS: usize = 8;
 pub const BRANCH_NAME_HASH_DIGITS: usize = 8;
+pub const UNKNOWN_COMMIT_AUTHOR: &str = "unknown";
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
 pub struct CommitHash {
@@ -569,6 +570,7 @@ impl<T: RawRepository> DistributedRepository<T> {
         &mut self,
         agenda_hash: &Hash256,
         proof: Vec<TypedSignature<Agenda>>,
+        timestamp: Timestamp,
     ) -> Result<CommitHash, Error> {
         // Check if the agenda branch is rebased on top of the `finalized` branch.
         let last_header_commit = self.raw.locate_branch(FINALIZED_BRANCH_NAME.into()).await?;
@@ -622,6 +624,7 @@ impl<T: RawRepository> DistributedRepository<T> {
             height: agenda.height,
             agenda_hash: agenda_commit.to_hash256(),
             proof,
+            timestamp,
         };
 
         let agenda_proof_commit = Commit::AgendaProof(agenda_proof.clone());
@@ -658,7 +661,7 @@ impl<T: RawRepository> DistributedRepository<T> {
     /// Creates an agenda commit on top of the `work` branch.
     pub async fn create_agenda(
         &mut self,
-        author: PublicKey,
+        author: MemberName,
     ) -> Result<(Agenda, CommitHash), Error> {
         let last_header = self.get_last_finalized_block_header().await?;
         let work_commit = self.raw.locate_branch(WORK_BRANCH_NAME.into()).await?;

--- a/repository/src/raw/implementation.rs
+++ b/repository/src/raw/implementation.rs
@@ -416,7 +416,17 @@ impl RawRepositoryImplInner {
         }
         .to_string();
 
-        let semantic_commit = SemanticCommit { title, body, diff };
+        let semantic_commit = SemanticCommit {
+            title,
+            body,
+            diff,
+            author: commit
+                .author()
+                .name()
+                .ok_or_else(|| Error::Unknown("failed to parse commit author".to_string()))?
+                .to_owned(),
+            timestamp: commit.author().when().seconds() * 1000,
+        };
 
         Ok(semantic_commit)
     }

--- a/repository/src/raw/mod.rs
+++ b/repository/src/raw/mod.rs
@@ -41,6 +41,10 @@ pub struct SemanticCommit {
     pub title: String,
     pub body: String,
     pub diff: Diff,
+    /// Note that this is only for the physical Git commit;
+    /// this is not handled by the Simperby core protocol
+    pub author: MemberName,
+    pub timestamp: Timestamp,
 }
 
 #[async_trait]

--- a/repository/src/raw/tests.rs
+++ b/repository/src/raw/tests.rs
@@ -465,6 +465,8 @@ async fn reserved_state() {
             title: "test".to_owned(),
             body: "test-body".to_owned(),
             diff: Diff::Reserved(Box::new(rs.clone())),
+            author: "doesn't matter".to_owned(),
+            timestamp: 0,
         })
         .await
         .unwrap();

--- a/repository/tests/integration_test.rs
+++ b/repository/tests/integration_test.rs
@@ -61,7 +61,7 @@ async fn basic_1() {
 
     // Step 0: create an agenda and let the client update that
     let (agenda, agenda_commit) = server_node_repo
-        .create_agenda(keys[0].0.clone())
+        .create_agenda(rs.query_name(&keys[0].0).unwrap())
         .await
         .unwrap();
     client_node_repo.fetch().await.unwrap();
@@ -75,6 +75,7 @@ async fn basic_1() {
             keys.iter()
                 .map(|(_, private_key)| TypedSignature::sign(&agenda, private_key).unwrap())
                 .collect(),
+            0,
         )
         .await
         .unwrap();

--- a/settlement/src/execution.rs
+++ b/settlement/src/execution.rs
@@ -38,7 +38,7 @@ pub struct TransferNonFungibleToken {
 /// Creates an execution transaction that will be delivered to the target chain once finalized.
 pub fn create_execution_transaction(
     execution: &Execution,
-    author: PublicKey,
+    author: MemberName,
     timestamp: Timestamp,
 ) -> Result<Transaction, String> {
     let head = match &execution.message {

--- a/settlement/tests/treasury.rs
+++ b/settlement/tests/treasury.rs
@@ -154,7 +154,7 @@ fn relay_1() {
                 receiver_address: string_to_hex("receiver-address"),
             }),
         },
-        PublicKey::zero(),
+        "doesn't matter".to_owned(),
         0,
     )
     .unwrap();
@@ -168,7 +168,7 @@ fn relay_1() {
                 receiver_address: string_to_hex("receiver-address"),
             }),
         },
-        PublicKey::zero(),
+        "doesn't matter".to_owned(),
         0,
     )
     .unwrap();
@@ -177,7 +177,7 @@ fn relay_1() {
 
     let agenda = Agenda {
         height: 1,
-        author: keys[0].0.clone(), // Note that keys[0] is member-0001
+        author: reserved_state.query_name(&keys[0].0).unwrap(),
         timestamp: 0,
         transactions_hash: Agenda::calculate_transactions_hash(&[tx1.clone(), tx2.clone()]),
     };
@@ -189,6 +189,7 @@ fn relay_1() {
             .iter()
             .map(|(_, private_key)| TypedSignature::sign(&agenda, private_key).unwrap())
             .collect::<Vec<_>>(),
+        timestamp: 0,
     }))
     .unwrap();
     let block_header = BlockHeader {


### PR DESCRIPTION
To support the 'signature' feature in the Git system.
- Author and committer will not be distinguished in Simperby.
- Email will be ignored.
- This change is important for DMS-propagated distributed repository: we have to regenerate the exact same commit (with the same signatures) in the remote side.