### PR TITLE
Add previous_block_hash to Agenda to prevent replay attack

### DIFF
--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -84,6 +84,7 @@ pub struct Agenda {
     pub author: MemberName,
     pub timestamp: Timestamp,
     pub transactions_hash: Hash256,
+    pub previous_block_hash: Hash256,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]

--- a/core/src/verify.rs
+++ b/core/src/verify.rs
@@ -140,6 +140,10 @@ impl CommitSequenceVerifier {
         })
     }
 
+    pub fn get_header(&self) -> &BlockHeader {
+        &self.header
+    }
+
     /// Returns the commits received so far.
     pub fn get_total_commits(&self) -> &[Commit] {
         &self.total_commits
@@ -281,6 +285,14 @@ impl CommitSequenceVerifier {
                         agenda.transactions_hash
                     )));
                 }
+                // Verify if agenda's last previous_block_hash matches with the actual previous block hash to prevent replay attacks
+                if agenda.previous_block_hash != self.header.to_hash256() {
+                    return Err(Error::InvalidArgument(format!(
+                        "invalid agenda previous_block_hash: expected {}, got {}",
+                        self.header.to_hash256(),
+                        agenda.previous_block_hash
+                    )));
+                }
                 self.phase = Phase::Agenda {
                     agenda: agenda.clone(),
                 };
@@ -317,6 +329,14 @@ impl CommitSequenceVerifier {
                         "invalid agenda transactions_hash: expected {}, got {}",
                         Agenda::calculate_transactions_hash(&transactions),
                         agenda.transactions_hash
+                    )));
+                }
+                // Verify if agenda's last previous_block_hash matches with the actual previous block hash to prevent replay attacks
+                if agenda.previous_block_hash != self.header.to_hash256() {
+                    return Err(Error::InvalidArgument(format!(
+                        "invalid agenda previous_block_hash: expected {}, got {}",
+                        self.header.to_hash256(),
+                        agenda.previous_block_hash
                     )));
                 }
                 self.phase = Phase::Agenda {
@@ -740,6 +760,7 @@ mod test {
             timestamp: 4,
             transactions_hash: agenda_transactions_hash,
             height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -762,6 +783,7 @@ mod test {
             timestamp: 1,
             transactions_hash: agenda_transactions_hash,
             height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -784,6 +806,7 @@ mod test {
             timestamp: 1,
             transactions_hash: agenda_transactions_hash,
             height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -828,6 +851,7 @@ mod test {
             timestamp: 1,
             transactions_hash: agenda_transactions_hash,
             height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -872,6 +896,7 @@ mod test {
             timestamp: 1,
             transactions_hash: agenda_transactions_hash,
             height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -916,6 +941,7 @@ mod test {
             timestamp: 1,
             transactions_hash: agenda_transactions_hash,
             height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -960,6 +986,7 @@ mod test {
             timestamp: 1,
             transactions_hash: agenda_transactions_hash,
             height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -1005,6 +1032,7 @@ mod test {
             timestamp: 1,
             transactions_hash: agenda_transactions_hash,
             height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -1050,6 +1078,7 @@ mod test {
             timestamp: 1,
             transactions_hash: agenda_transactions_hash,
             height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -1140,6 +1169,7 @@ mod test {
             timestamp: 4,
             transactions_hash: agenda_transactions_hash,
             height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply block commit at agenda phase
@@ -1165,6 +1195,7 @@ mod test {
             timestamp: 1,
             transactions_hash: agenda_transactions_hash,
             height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply transaction commit at agenda phase
@@ -1183,6 +1214,7 @@ mod test {
             timestamp: 1,
             transactions_hash: agenda_transactions_hash,
             height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -1218,6 +1250,7 @@ mod test {
             timestamp: 1,
             transactions_hash: agenda_transactions_hash,
             height: 0,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_commit(&agenda))
             .unwrap_err();
@@ -1240,6 +1273,7 @@ mod test {
             timestamp: 1,
             transactions_hash: agenda_transactions_hash,
             height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_commit(&agenda))
             .unwrap_err();
@@ -1259,6 +1293,7 @@ mod test {
             timestamp: 2,
             transactions_hash: agenda_transactions_hash,
             height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_commit(&agenda))
             .unwrap_err();
@@ -1277,6 +1312,7 @@ mod test {
             timestamp: 0,
             transactions_hash: Agenda::calculate_transactions_hash(&[]),
             height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_commit(&agenda))
             .unwrap_err();
@@ -1293,6 +1329,7 @@ mod test {
             timestamp: 1,
             transactions_hash: agenda_transactions_hash,
             height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda commit again
@@ -1311,6 +1348,7 @@ mod test {
             timestamp: 1,
             transactions_hash: agenda_transactions_hash,
             height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -1346,6 +1384,7 @@ mod test {
             timestamp: 1,
             transactions_hash: agenda_transactions_hash,
             height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit with invalid height
@@ -1356,6 +1395,7 @@ mod test {
                 timestamp: 1,
                 transactions_hash: agenda_transactions_hash,
                 height: 0,
+                previous_block_hash: csv.header.to_hash256(),
             },
             agenda.to_hash256(),
         ))
@@ -1373,6 +1413,7 @@ mod test {
             timestamp: 1,
             transactions_hash: agenda_transactions_hash,
             height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit with invalid agenda hash
@@ -1395,6 +1436,7 @@ mod test {
             timestamp: 1,
             transactions_hash: agenda_transactions_hash,
             height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit with invalid signature
@@ -1405,6 +1447,7 @@ mod test {
                 timestamp: 0,
                 transactions_hash: Hash256::zero(),
                 height: csv.header.height + 1,
+                previous_block_hash: csv.header.to_hash256(),
             },
             agenda.to_hash256(),
         ))
@@ -1422,6 +1465,7 @@ mod test {
             timestamp: 1,
             transactions_hash: agenda_transactions_hash,
             height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
         // Apply agenda-proof commit
@@ -1454,6 +1498,7 @@ mod test {
             timestamp: 2,
             transactions_hash: agenda_transactions_hash,
             height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_proof_commit(
             &validator_keypair,
@@ -1483,6 +1528,7 @@ mod test {
             timestamp: 1,
             transactions_hash: agenda_transactions_hash,
             height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
         };
         csv.apply_commit(&generate_agenda_proof_commit(
             &validator_keypair,

--- a/core/tests/integration_tests.rs
+++ b/core/tests/integration_tests.rs
@@ -26,6 +26,7 @@ fn basic1() {
         author: rs.query_name(&keys[0].0).unwrap(),
         timestamp: 0,
         transactions_hash: Agenda::calculate_transactions_hash(&[tx.clone()]),
+        previous_block_hash: csv.get_header().to_hash256(),
     };
     csv.apply_commit(&Commit::Agenda(agenda.clone())).unwrap();
     csv.apply_commit(&Commit::AgendaProof(AgendaProof {
@@ -41,7 +42,7 @@ fn basic1() {
     let block_header = BlockHeader {
         author: keys[0].0.clone(),
         prev_block_finalization_proof: genesis_info.genesis_proof,
-        previous_hash: genesis_info.header.to_hash256(),
+        previous_hash: csv.get_header().to_hash256(),
         height: 1,
         timestamp: 0,
         commit_merkle_root: BlockHeader::calculate_commit_merkle_root(
@@ -109,6 +110,7 @@ fn basic2() {
         author: reserved_state.query_name(&keys[1].0).unwrap(),
         timestamp: 0,
         transactions_hash: Agenda::calculate_transactions_hash(&[tx.clone()]),
+        previous_block_hash: csv.get_header().to_hash256(),
     };
     csv.apply_commit(&Commit::Agenda(agenda.clone())).unwrap();
     csv.apply_commit(&Commit::AgendaProof(AgendaProof {
@@ -124,7 +126,7 @@ fn basic2() {
     let block_header = BlockHeader {
         author: keys[1].0.clone(),
         prev_block_finalization_proof: genesis_info.genesis_proof,
-        previous_hash: genesis_info.header.to_hash256(),
+        previous_hash: csv.get_header().to_hash256(),
         height: 1,
         timestamp: 0,
         commit_merkle_root: BlockHeader::calculate_commit_merkle_root(
@@ -191,6 +193,7 @@ fn basic3() {
         author: rs.query_name(&keys[0].0).unwrap(),
         timestamp,
         transactions_hash: Agenda::calculate_transactions_hash(&[tx.clone()]),
+        previous_block_hash: csv.get_header().to_hash256(),
     };
     csv.apply_commit(&Commit::Agenda(agenda.clone())).unwrap();
 
@@ -223,7 +226,7 @@ fn basic3() {
     let block_header = BlockHeader {
         author: keys[0].0.clone(),
         prev_block_finalization_proof: genesis_info.genesis_proof,
-        previous_hash: genesis_info.header.to_hash256(),
+        previous_hash: csv.get_header().to_hash256(),
         height,
         timestamp,
         commit_merkle_root: BlockHeader::calculate_commit_merkle_root(
@@ -289,6 +292,7 @@ fn basic3() {
         author: rs.query_name(&keys[1].0).unwrap(),
         timestamp,
         transactions_hash: Agenda::calculate_transactions_hash(&[]),
+        previous_block_hash: block_header.to_hash256(),
     };
     csv.apply_commit(&Commit::Agenda(agenda.clone())).unwrap();
 

--- a/repository/src/format.rs
+++ b/repository/src/format.rs
@@ -317,6 +317,7 @@ mod tests {
             author: "doesn't matter".to_owned(),
             timestamp: 123,
             transactions_hash: Hash256::hash("hello"),
+            previous_block_hash: Hash256::hash("hello"),
         });
         assert_eq!(
             agenda,

--- a/repository/src/interpret/create.rs
+++ b/repository/src/interpret/create.rs
@@ -123,6 +123,7 @@ pub async fn create_agenda(
         timestamp: get_timestamp(),
         transactions_hash: Agenda::calculate_transactions_hash(&transactions),
         height: last_header.height + 1,
+        previous_block_hash: last_header.to_hash256(),
     };
     let agenda_commit = Commit::Agenda(agenda.clone());
     verifier.apply_commit(&agenda_commit).map_err(|_| {

--- a/settlement/src/tests.rs
+++ b/settlement/src/tests.rs
@@ -117,6 +117,7 @@ pub async fn scenario_1(
         author: chain_info.reserved_state.consensus_leader_order[0].clone(),
         timestamp: 0,
         transactions_hash: Agenda::calculate_transactions_hash(&transactions),
+        previous_block_hash: chain_info.last_finalized_header.to_hash256(),
     };
     csv.apply_commit(&Commit::Agenda(agenda.clone())).unwrap();
     csv.apply_commit(&Commit::AgendaProof(AgendaProof {

--- a/settlement/tests/treasury.rs
+++ b/settlement/tests/treasury.rs
@@ -182,6 +182,7 @@ fn relay_1() {
         author: reserved_state.query_name(&keys[0].0).unwrap(),
         timestamp: 0,
         transactions_hash: Agenda::calculate_transactions_hash(&[tx1.clone(), tx2.clone()]),
+        previous_block_hash: csv.get_header().to_hash256(),
     };
     csv.apply_commit(&Commit::Agenda(agenda.clone())).unwrap();
     csv.apply_commit(&Commit::AgendaProof(AgendaProof {
@@ -197,7 +198,7 @@ fn relay_1() {
     let block_header = BlockHeader {
         author: keys[0].0.clone(), // Note that keys[0] is member-0001
         prev_block_finalization_proof: genesis_info.genesis_proof,
-        previous_hash: genesis_info.header.to_hash256(),
+        previous_hash: csv.get_header().to_hash256(),
         height: 1,
         timestamp: 0,
         commit_merkle_root: BlockHeader::calculate_commit_merkle_root(


### PR DESCRIPTION
## Implemented
* [x] add the field `previous_block_hash` to the Agenda struct
* [x] create the method `verify_agenda_integrity` that is implemented on the Agenda struct
* [x] modify the preparation payloads for the testing methods that are affected sequentially

## Note
* The specification is suggested on the issue here. https://github.com/postech-dao/simperby/issues/417