### PR TITLE
Use read_unaligned() in the header decoding test

### DIFF
--- a/core/src/hash.rs
+++ b/core/src/hash.rs
@@ -165,11 +165,12 @@ mod tests {
     use super::*;
     use crate::serde_spb;
     use std::mem::size_of;
+    use std::ptr::read_unaligned;
 
     unsafe fn read<T: Clone>(offset: &mut usize, data: &[u8]) -> T {
         let size = size_of::<T>();
         let p = data[*offset..*offset + size].as_ptr() as *const T;
-        let x = (*p).clone();
+        let x = read_unaligned(p);
         *offset += size;
         x
     }


### PR DESCRIPTION
fixes #455 

use read_unaligned() instead of dereferencing the unaligned pointer to mitigate the undefined behavior.