### PR TITLE
Add test-case about phase_mismatch_for_agenda_proof_commit3

### DIFF
--- a/core/src/verify.rs
+++ b/core/src/verify.rs
@@ -1606,10 +1606,60 @@ mod test {
     #[ignore]
     #[test]
     /// Test the case where the agenda proof commit is invalid because it is extra-agenda transaction phase.
-    /// This test case is ignored because the extra-agenda transaction is not implemented yet.
-    /// TODO: enable this test case when the extra-agenda transaction is implemented.
     fn phase_mismatch_for_agenda_proof_commit3() {
-        todo!("Implement this test")
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
+        // Apply agenda commit
+        let agenda_transactions_hash = calculate_agenda_transactions_hash(csv.phase.clone());
+        let agenda: Agenda = Agenda {
+            author: reserved_state.query_name(&validator_keypair[0].0).unwrap(),
+            timestamp: 1,
+            transactions_hash: agenda_transactions_hash,
+            height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
+        };
+        csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
+        // Apply agenda-proof commit
+        csv.apply_commit(&generate_agenda_proof_commit(
+            &validator_keypair,
+            &agenda,
+            agenda.to_hash256(),
+        ))
+        .unwrap();
+        // Apply extra-agenda transaction commit
+        // delegator: member-0, delegatee: member-1
+        let delegator = reserved_state.members[0].clone();
+        let delegator_private_key = validator_keypair[0].1.clone();
+        let delegatee = reserved_state.members[1].clone();
+        let delegation_transaction_data: DelegationTransactionData = DelegationTransactionData {
+            delegator: delegator.name,
+            delegatee: delegatee.name,
+            governance: true,
+            block_height: csv.header.height + 1,
+            timestamp: 2,
+            chain_name: reserved_state.genesis_info.chain_name.clone(),
+        };
+        let proof =
+            TypedSignature::sign(&delegation_transaction_data, &delegator_private_key).unwrap();
+        csv.apply_commit(&generate_extra_agenda_transaction(
+            &delegation_transaction_data,
+            proof,
+        ))
+        .unwrap();
+        // Apply agenda-proof commit at extra-agenda transaction phase
+        let agenda_transactions_hash = Agenda::calculate_transactions_hash(&[]);
+        let agenda: Agenda = Agenda {
+            author: reserved_state.query_name(&validator_keypair[2].0).unwrap(),
+            timestamp: 3,
+            transactions_hash: agenda_transactions_hash,
+            height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
+        };
+        csv.apply_commit(&generate_agenda_proof_commit(
+            &validator_keypair,
+            &agenda,
+            agenda.to_hash256(),
+        ))
+        .unwrap_err();
     }
 
     #[test]


### PR DESCRIPTION
issue #345 
Test the case where the agenda proof commit is invalid because it is extra-agenda transaction phase.