### PR TITLE
Add test-case about invalid_delegate_transaction_with_invalid_delegator1 in CommitSequenceVerifier

### DIFF
--- a/core/src/reserved.rs
+++ b/core/src/reserved.rs
@@ -88,6 +88,17 @@ impl ReservedState {
                 tx.data.delegator
             ));
         }
+        if let Some(key) = self.query_public_key(&tx.data.delegator) {
+            if &key != tx.proof.signer() {
+                return Err(
+                    "the key used for the proof does not match the key in the reserved state"
+                        .to_string(),
+                );
+            }
+        }
+        if !self.is_member(&tx.data.delegatee) {
+            return Err("delegatee not found by name".to_string());
+        }
         if tx.proof.verify(&tx.data).is_err() {
             return Err("delegation proof verification failed".to_string());
         }
@@ -139,6 +150,15 @@ impl ReservedState {
             }
         }
         None
+    }
+
+    pub fn is_member(&self, name: &MemberName) -> bool {
+        for member in &self.members {
+            if &member.name == name {
+                return true;
+            }
+        }
+        false
     }
 }
 

--- a/core/src/reserved.rs
+++ b/core/src/reserved.rs
@@ -117,6 +117,14 @@ impl ReservedState {
     }
 
     pub fn apply_undelegate(&mut self, tx: &TxUndelegate) -> Result<Self, String> {
+        if let Some(key) = self.query_public_key(&tx.data.delegator) {
+            if &key != tx.proof.signer() {
+                return Err(
+                    "the key used for the proof does not match the key in the reserved state"
+                        .to_string(),
+                );
+            }
+        }
         if tx.proof.verify(&tx.data).is_err() {
             return Err("delegation proof verification failed".to_string());
         }

--- a/core/src/verify.rs
+++ b/core/src/verify.rs
@@ -1686,10 +1686,52 @@ mod test {
     #[ignore]
     #[test]
     // Test the case where the `Delegate` extra-agenda transaction is invalid because the delegator is not a member.
-    /// This test case is ignored because the extra-agenda transaction is not implemented yet.
-    // TODO: enable this test case when the extra-agenda transaction is implemented.
     fn invalid_delegate_transaction_with_invalid_delegator1() {
-        todo!("Implement this test")
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
+        // Apply agenda commit
+        let agenda_transactions_hash = calculate_agenda_transactions_hash(csv.phase.clone());
+        let agenda: Agenda = Agenda {
+            author: reserved_state.query_name(&validator_keypair[0].0).unwrap(),
+            timestamp: 1,
+            transactions_hash: agenda_transactions_hash,
+            height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
+        };
+        csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
+        // Apply agenda-proof commit
+        csv.apply_commit(&generate_agenda_proof_commit(
+            &validator_keypair,
+            &agenda,
+            agenda.to_hash256(),
+        ))
+        .unwrap();
+        // Apply extra-agenda transaction commit
+        // delegator: not-a-member, delegatee: member-0
+        let (delegator_public_key, delegator_private_key) = generate_keypair_random();
+        let delegator = Member {
+            public_key: delegator_public_key,
+            name: "not-a-member".to_string(),
+            governance_voting_power: 100,
+            consensus_voting_power: 100,
+            governance_delegatee: None,
+            consensus_delegatee: None,
+        };
+        let delegatee = reserved_state.members[0].clone();
+        let delegation_transaction_data: DelegationTransactionData = DelegationTransactionData {
+            delegator: delegator.name,
+            delegatee: delegatee.name,
+            governance: true,
+            block_height: csv.header.height + 1,
+            timestamp: 2,
+            chain_name: reserved_state.genesis_info.chain_name,
+        };
+        let proof: TypedSignature<DelegationTransactionData> =
+            TypedSignature::sign(&delegation_transaction_data, &delegator_private_key).unwrap();
+        csv.apply_commit(&generate_extra_agenda_transaction(
+            &delegation_transaction_data,
+            proof,
+        ))
+        .unwrap_err();
     }
 
     #[ignore]


### PR DESCRIPTION
issue #345 
Test the case where the `Delegate` extra-agenda transaction is invalid because the delegator is not a member.
This test case didn't pass.