### PR TITLE
Fix wrong condition for 4f precommit

### DIFF
--- a/vetomint/src/progress.rs
+++ b/vetomint/src/progress.rs
@@ -367,7 +367,7 @@ fn on_4f_nil_precommit(
     if target_round != state.round {
         return Vec::new();
     }
-    if state.get_total_precommits_on_nil(target_round) * 2 > state.get_total_voting_power() * 3 {
+    if state.get_total_precommits_on_nil(target_round) * 3 > state.get_total_voting_power() * 2 {
         start_round(state, target_round + 1, timestamp)
     } else {
         Vec::new()


### PR DESCRIPTION
## Summary
In order to check if the node has received 4f precommits as [vetomint spec](https://github.com/postech-dao/simperby/blob/main/docs/vetomint_spec/vetomint-spec.pdf) suggested, the condition should be edited.

### AS-IS
total_precommits_on_nil  / total_voting_power > 3/2

### TO-BE
total_precommits_on_nil  / total_voting_power > 2/3