### PR TITLE
Adjust timeout for computation-heavy test

### DIFF
--- a/network/src/dms/tests.rs
+++ b/network/src/dms/tests.rs
@@ -164,7 +164,7 @@ async fn multi_1() {
             Some(Duration::from_millis(400)),
             Some(Duration::from_millis(400)),
             Duration::from_millis(50),
-            Duration::from_millis(3000),
+            Duration::from_millis(10000),
         ));
         client_dmses.push(dms);
     }


### PR DESCRIPTION
fix #461

increase `final_sleep` from 3 sec to 10 sec