### PR TITLE
Invalid delegate transaction with invalid delegator2

### DIFF
--- a/core/src/reserved.rs
+++ b/core/src/reserved.rs
@@ -114,6 +114,9 @@ impl ReservedState {
         }
         for delegator in &mut self.members {
             if delegator.name == tx.data.delegator {
+                if delegator.consensus_delegatee.is_some() {
+                    return Err("consensus_delegatee is already set".to_string());
+                }
                 if tx.data.governance {
                     delegator.governance_delegatee = Some(tx.data.delegatee.clone());
                     delegator.consensus_delegatee = Some(tx.data.delegatee.clone());


### PR DESCRIPTION
issue #345 
Test the case where the `Delegate` extra-agenda transaction is invalid because the delegator has already delegated.
I'm not sure if we need this test case.
Currently, the logic for delegating voting rights entirely depends on whether there's delegatee information in the ReservedState's member object. It executes the new_state_governance_set for all members' public keys to calculate the voting rights at that moment.
If there's a delegation from member a to b and it's changed to a to c, it seems we only need to change the delegatee in the member object. I'm wondering if there's a need to limit this.