### PR TITLE
Add test-case invalid_delegate_transaction_with_invalid_signature

### DIFF
--- a/core/src/verify.rs
+++ b/core/src/verify.rs
@@ -1993,10 +1993,46 @@ mod test {
     #[ignore]
     #[test]
     // Test the case where the `Delegate` extra-agenda transaction is invalid because the signature is invalid.
-    /// This test case is ignored because the extra-agenda transaction is not implemented yet.
-    // TODO: enable this test case when the extra-agenda transaction is implemented.
     fn invalid_delegate_transaction_with_invalid_signature() {
-        todo!("Implement this test")
+        let (validator_keypair, reserved_state, mut csv) = setup_test(4);
+        // Apply agenda commit
+        let agenda_transactions_hash = calculate_agenda_transactions_hash(csv.phase.clone());
+        let agenda: Agenda = Agenda {
+            author: reserved_state.query_name(&validator_keypair[0].0).unwrap(),
+            timestamp: 1,
+            transactions_hash: agenda_transactions_hash,
+            height: csv.header.height + 1,
+            previous_block_hash: csv.header.to_hash256(),
+        };
+        csv.apply_commit(&generate_agenda_commit(&agenda)).unwrap();
+        // Apply agenda-proof commit
+        csv.apply_commit(&generate_agenda_proof_commit(
+            &validator_keypair,
+            &agenda,
+            agenda.to_hash256(),
+        ))
+        .unwrap();
+        // Apply extra-agenda transaction commit
+        // delegator: member-1, delegatee: member-2
+        // The signature is signed by member-3's private key
+        let delegator = reserved_state.members[1].clone();
+        let non_delegator_private_key = validator_keypair[3].1.clone();
+        let delegatee = reserved_state.members[2].clone();
+        let delegation_transaction_data: DelegationTransactionData = DelegationTransactionData {
+            delegator: delegator.name,
+            delegatee: delegatee.name,
+            governance: true,
+            block_height: csv.header.height + 1,
+            timestamp: 2,
+            chain_name: reserved_state.genesis_info.chain_name,
+        };
+        let proof =
+            TypedSignature::sign(&delegation_transaction_data, &non_delegator_private_key).unwrap();
+        csv.apply_commit(&generate_extra_agenda_transaction(
+            &delegation_transaction_data,
+            proof,
+        ))
+        .unwrap_err();
     }
 
     #[ignore]


### PR DESCRIPTION
issue #345 
Test the case where the `Delegate` extra-agenda transaction is invalid because the signature is invalid.