### PR TITLE
Add multi-block integration tests

### DIFF
--- a/repository/src/interpret/works.rs
+++ b/repository/src/interpret/works.rs
@@ -17,6 +17,8 @@ async fn advance_finalized_branch(
     raw.checkout(FP_BRANCH_NAME.into()).await?;
     raw.create_semantic_commit(format::fp_to_semantic_commit(&finalization_proof))
         .await?;
+    raw.checkout_detach(to_be_finalized_block_commit_hash)
+        .await?;
     Ok(())
 }
 

--- a/simperby/tests/integration_test.rs
+++ b/simperby/tests/integration_test.rs
@@ -217,22 +217,19 @@ async fn normal_2() {
     let auth = Auth {
         private_key: keys[3].1.clone(),
     };
-    let server_config_ = server_config.clone();
-    let server_dir_ = server_dir.clone();
-    let auth_ = auth.clone();
-
-    let server_task = tokio::spawn(async move {
-        let client = Client::open(&server_dir_, Config {}, auth_).await.unwrap();
+    let client = Client::open(&server_dir.clone(), Config {}, auth.clone())
+        .await
+        .unwrap();
+    let server_task =
         client
             .serve(
-                server_config_,
+                server_config.clone(),
                 simperby_repository::server::PushVerifier::VerifierExecutable(
                     build_simple_git_server(),
                 ),
             )
             .await
-            .unwrap()
-    });
+            .unwrap();
 
     // Setup peer network.
     sleep_ms(500).await;
@@ -299,7 +296,7 @@ async fn normal_2() {
     }
 
     // Stop and restart the server.
-    server_task.await.unwrap().abort();
+    server_task.abort();
 
     run_command(format!(
         "cd {server_dir}/.simperby/governance/dms/ && rm state.json"
@@ -463,22 +460,19 @@ async fn normal_2_premade() {
     let auth = Auth {
         private_key: keys[3].1.clone(),
     };
-    let server_config_ = server_config.clone();
-    let server_dir_ = server_dir.clone();
-    let auth_ = auth.clone();
-
-    let server_task = tokio::spawn(async move {
-        let client = Client::open(&server_dir_, Config {}, auth_).await.unwrap();
+    let client = Client::open(&server_dir.clone(), Config {}, auth.clone())
+        .await
+        .unwrap();
+    let server_task =
         client
             .serve(
-                server_config_,
+                server_config.clone(),
                 simperby_repository::server::PushVerifier::VerifierExecutable(
                     build_simple_git_server(),
                 ),
             )
             .await
-            .unwrap()
-    });
+            .unwrap();
 
     // Setup peer network.
     sleep_ms(500).await;
@@ -547,7 +541,7 @@ async fn normal_2_premade() {
     }
 
     // Stop and restart the server.
-    server_task.await.unwrap().abort();
+    server_task.abort();
 
     run_command(format!(
         "cd {server_dir}/.simperby/governance/dms/ && rm state.json"

--- a/simperby/tests/integration_test.rs
+++ b/simperby/tests/integration_test.rs
@@ -45,7 +45,6 @@ fn build_simple_git_server() -> String {
 }
 
 /// Make only one block without server participation.
-#[ignore]
 #[tokio::test]
 async fn normal_1() {
     setup_test();
@@ -171,7 +170,6 @@ async fn normal_1() {
 }
 
 /// Make two blocks with server participation.
-#[ignore]
 #[tokio::test]
 async fn normal_2() {
     setup_test();
@@ -390,7 +388,6 @@ async fn normal_2() {
 }
 
 /// Make two blocks with server participation and premade one-block repository.
-#[ignore]
 #[tokio::test]
 async fn normal_2_premade() {
     setup_test();

--- a/simperby/tests/integration_test.rs
+++ b/simperby/tests/integration_test.rs
@@ -363,6 +363,242 @@ async fn normal_2() {
     }
 }
 
+/// Make two blocks with server participation and premade one-block repository.
+#[ignore]
+#[tokio::test]
+async fn normal_2_premade() {
+    setup_test();
+    let (fi, keys) = test_utils::generate_fi(4);
+    let server_config = generate_server_config();
+
+    // Setup repository and server.
+    let server_dir = create_temp_dir();
+    make_repository_with_one_block(fi.clone(), keys.clone(), server_dir.clone()).await;
+
+    // Setup clients.
+    let mut clients = Vec::new();
+    for (_, key) in keys.iter() {
+        let dir = create_temp_dir();
+        run_command(format!("cp -a {server_dir}/. {dir}/")).await;
+        let auth = Auth {
+            private_key: key.clone(),
+        };
+        let port = server_config.peers_port;
+        run_command(format!(
+            "cd {dir}/.simperby/governance/dms/ && rm state.json"
+        ))
+        .await;
+        run_command(format!(
+            "cd {dir}/.simperby/consensus/dms/ && rm state.json"
+        ))
+        .await;
+        run_command(format!(
+            "cd {dir}/.simperby/consensus/state/ && rm state.json"
+        ))
+        .await;
+        let mut client = Client::open(&dir, Config {}, auth).await.unwrap();
+        client
+            .add_peer(
+                fi.reserved_state.members[3].name.clone(),
+                format!("127.0.0.1:{port}").parse().unwrap(),
+            )
+            .await
+            .unwrap();
+        clients.push(client);
+    }
+
+    // Add push configs to server repository.
+    run_command(format!(
+        "cd {server_dir} && git config receive.advertisePushOptions true"
+    ))
+    .await;
+    run_command(format!(
+        "cd {server_dir} && git config sendpack.sideband false"
+    ))
+    .await;
+
+    run_command(format!(
+        "cd {server_dir}/.simperby/governance/dms/ && rm state.json"
+    ))
+    .await;
+    run_command(format!(
+        "cd {server_dir}/.simperby/consensus/dms/ && rm state.json"
+    ))
+    .await;
+    run_command(format!(
+        "cd {server_dir}/.simperby/consensus/state/ && rm state.json"
+    ))
+    .await;
+
+    // Run server.
+    let auth = Auth {
+        private_key: keys[3].1.clone(),
+    };
+    let server_config_ = server_config.clone();
+    let server_dir_ = server_dir.clone();
+
+    tokio::spawn(async move {
+        let mut client = Client::open(&server_dir_, Config {}, auth).await.unwrap();
+        let tag = client
+            .repository()
+            .get_raw()
+            .read()
+            .await
+            .list_tags()
+            .await
+            .unwrap()[0]
+            .clone();
+        client
+            .repository_mut()
+            .get_raw()
+            .write()
+            .await
+            .remove_tag(tag)
+            .await
+            .unwrap();
+        let task = client
+            .serve(
+                server_config_,
+                simperby_repository::server::PushVerifier::VerifierExecutable(
+                    build_simple_git_server(),
+                ),
+            )
+            .await
+            .unwrap();
+        task.await.unwrap().unwrap();
+    });
+
+    // Setup peer network.
+    sleep_ms(200).await;
+    for client in clients.iter_mut() {
+        client.update_peer().await.unwrap();
+    }
+
+    sync_each_other(&mut clients).await;
+
+    // Make a first block, Step 1 ~ 3.
+    // Step 1: create an agenda and propagate it.
+    log::info!("STEP 1");
+    let (_, agenda_commit) = clients[0]
+        .repository_mut()
+        .create_agenda(fi.reserved_state.members[0].name.clone())
+        .await
+        .unwrap();
+
+    sync_each_other(&mut clients).await;
+    for client in clients.iter_mut() {
+        client.vote(agenda_commit).await.unwrap();
+    }
+    sync_each_other(&mut clients).await;
+
+    // Step 2: create block and run consensus.
+    log::info!("STEP 2");
+    let proposer_public_key = clients[0].auth().private_key.public_key();
+    clients[0]
+        .repository_mut()
+        .create_block(proposer_public_key)
+        .await
+        .unwrap();
+    sync_each_other(&mut clients).await;
+    for client in clients.iter_mut() {
+        client.progress_for_consensus().await.unwrap();
+    }
+    sync_each_other(&mut clients).await;
+    for client in clients.iter_mut() {
+        client.progress_for_consensus().await.unwrap();
+    }
+    sync_each_other(&mut clients).await;
+    for client in clients.iter_mut() {
+        client.progress_for_consensus().await.unwrap();
+    }
+    sync_each_other(&mut clients).await;
+    for client in clients.iter_mut() {
+        client.progress_for_consensus().await.unwrap();
+    }
+    sync_each_other(&mut clients).await;
+
+    // Step 3: check the result.
+    log::info!("STEP 3");
+    for client in clients.iter() {
+        let raw_repo = client.repository().get_raw();
+        let raw_repo_ = raw_repo.read().await;
+        let finalized = raw_repo_
+            .locate_branch("finalized".to_owned())
+            .await
+            .unwrap();
+        let title = raw_repo_
+            .read_semantic_commit(finalized)
+            .await
+            .unwrap()
+            .title;
+        assert_eq!(title, ">block: 2");
+    }
+
+    // Setup peer network.
+    sleep_ms(200).await;
+    for client in clients.iter_mut() {
+        client.update_peer().await.unwrap();
+    }
+
+    // Make a second block, Step 4 ~ 6.
+    // Step 4: create an agenda and propagate it.
+    log::info!("STEP 4");
+    let (_, agenda_commit) = clients[1]
+        .repository_mut()
+        .create_agenda(fi.reserved_state.members[1].name.clone())
+        .await
+        .unwrap();
+
+    sync_each_other(&mut clients).await;
+    for client in clients.iter_mut() {
+        client.vote(agenda_commit).await.unwrap();
+    }
+    sync_each_other(&mut clients).await;
+
+    // Step 5: create block and run consensus.
+    log::info!("STEP 5");
+    let proposer_public_key = clients[1].auth().private_key.public_key();
+    clients[1]
+        .repository_mut()
+        .create_block(proposer_public_key)
+        .await
+        .unwrap();
+    sync_each_other(&mut clients).await;
+    for client in clients.iter_mut() {
+        client.progress_for_consensus().await.unwrap();
+    }
+    sync_each_other(&mut clients).await;
+    for client in clients.iter_mut() {
+        client.progress_for_consensus().await.unwrap();
+    }
+    sync_each_other(&mut clients).await;
+    for client in clients.iter_mut() {
+        client.progress_for_consensus().await.unwrap();
+    }
+    sync_each_other(&mut clients).await;
+    for client in clients.iter_mut() {
+        client.progress_for_consensus().await.unwrap();
+    }
+    sync_each_other(&mut clients).await;
+
+    // Step 6: check the result.
+    log::info!("STEP 6");
+    for client in clients.iter() {
+        let raw_repo = client.repository().get_raw();
+        let raw_repo_ = raw_repo.read().await;
+        let finalized = raw_repo_
+            .locate_branch("finalized".to_owned())
+            .await
+            .unwrap();
+        let title = raw_repo_
+            .read_semantic_commit(finalized)
+            .await
+            .unwrap()
+            .title;
+        assert_eq!(title, ">block: 3");
+    }
+}
+
 async fn make_repository_with_one_block(
     fi: FinalizationInfo,
     keys: Vec<(PublicKey, PrivateKey)>,

--- a/simperby/tests/integration_test.rs
+++ b/simperby/tests/integration_test.rs
@@ -44,6 +44,7 @@ fn build_simple_git_server() -> String {
     )
 }
 
+/// Make only one block without server participation.
 #[ignore]
 #[tokio::test]
 async fn normal_1() {
@@ -51,7 +52,7 @@ async fn normal_1() {
     let (fi, keys) = test_utils::generate_fi(4);
     let server_config = generate_server_config();
 
-    // Setup repository and server
+    // Setup repository and server.
     let server_dir = create_temp_dir();
     setup_pre_genesis_repository(&server_dir, fi.reserved_state.clone()).await;
     Client::genesis(&server_dir).await.unwrap();
@@ -66,7 +67,7 @@ async fn normal_1() {
     ))
     .await;
 
-    // Setup clients
+    // Setup clients.
     let mut clients = Vec::new();
     for (_, key) in keys.iter().take(3) {
         let dir = create_temp_dir();
@@ -86,7 +87,7 @@ async fn normal_1() {
         clients.push(client);
     }
 
-    // Run server
+    // Run server.
     let auth = Auth {
         private_key: keys[3].1.clone(),
     };
@@ -106,13 +107,13 @@ async fn normal_1() {
         task.await.unwrap().unwrap();
     });
 
-    // Setup peer network
+    // Setup peer network.
     sleep_ms(200).await;
     for client in clients.iter_mut() {
         client.update_peer().await.unwrap();
     }
 
-    // Step 1: create an agenda and propagate it
+    // Step 1: create an agenda and propagate it.
     log::info!("STEP 1");
     let (_, agenda_commit) = clients[0]
         .repository_mut()
@@ -126,7 +127,7 @@ async fn normal_1() {
     }
     sync_each_other(&mut clients).await;
 
-    // Step 2: create block and run consensus
+    // Step 2: create block and run consensus.
     log::info!("STEP 2");
     let proposer_public_key = clients[0].auth().private_key.public_key();
     clients[0]
@@ -152,7 +153,7 @@ async fn normal_1() {
     }
     sync_each_other(&mut clients).await;
 
-    // Step 3: check the result
+    // Step 3: check the result.
     for client in clients {
         let raw_repo = client.repository().get_raw();
         let raw_repo_ = raw_repo.read().await;

--- a/simperby/tests/integration_test.rs
+++ b/simperby/tests/integration_test.rs
@@ -108,7 +108,7 @@ async fn normal_1() {
     });
 
     // Setup peer network.
-    sleep_ms(1200).await;
+    sleep_ms(500).await;
     for client in clients.iter_mut() {
         client.update_peer().await.unwrap();
     }
@@ -235,7 +235,7 @@ async fn normal_2() {
     });
 
     // Setup peer network.
-    sleep_ms(200).await;
+    sleep_ms(500).await;
     for client in clients.iter_mut() {
         client.update_peer().await.unwrap();
     }
@@ -328,7 +328,7 @@ async fn normal_2() {
     });
 
     // Setup peer network.
-    sleep_ms(200).await;
+    sleep_ms(500).await;
     for client in clients.iter_mut() {
         client.update_peer().await.unwrap();
     }
@@ -481,7 +481,7 @@ async fn normal_2_premade() {
     });
 
     // Setup peer network.
-    sleep_ms(200).await;
+    sleep_ms(500).await;
     for client in clients.iter_mut() {
         client.update_peer().await.unwrap();
     }
@@ -576,7 +576,7 @@ async fn normal_2_premade() {
     });
 
     // Setup peer network.
-    sleep_ms(200).await;
+    sleep_ms(500).await;
     for client in clients.iter_mut() {
         client.update_peer().await.unwrap();
     }


### PR DESCRIPTION
Multi block test cases with server participation are added. 
1. `normal_2` is about making two blocks with server participation.
2. `normal_2_premade` is about making two blocks with server participation that the first block is already made by manual, not by network.

Since @junha1 and I fixed some bugs when making multiple blocks, this test results ensure that 4 clients including server can successfully make two blocks with network. The important things to consider are that server node should participate in the consensus and should stop and restart the server after making each block.